### PR TITLE
Support removing any kind of module with npm run remove

### DIFF
--- a/scripts/add.js
+++ b/scripts/add.js
@@ -9,7 +9,14 @@ const modules = process.argv.slice(2);
 const cwd = process.cwd();
 const demoDir = path.join(process.cwd(), config.demo.directory);
 
-modules.map(module => {
+const filterMeta = (src, _) => path.basename(src) != "meta.json";
+
+const copy = (origin, target) => {
+  fs.mkdirSync(target, { recursive: true });
+  fse.copySync(origin, target, { filter: filterMeta });
+};
+
+modules.map((module) => {
   process.chdir(cwd);
   const originModuleDir = path.join(process.cwd(), "modules", module);
   const meta = JSON.parse(
@@ -17,34 +24,36 @@ modules.map(module => {
   );
   const targetModuleDir = path.join(demoDir, meta.root);
 
-  const filterMeta = (src, _) => path.basename(src) != "meta.json";
+  const getDeps = (packageJSON) => {
+    let packages = [];
+    if (packageJSON.hasOwnProperty("x-dependencies")) {
+      const deps = packageJSON["x-dependencies"];
+      for (const [key, value] of Object.entries(deps)) {
+        packages.push(`${key}@${value}`);
+      }
+    }
+    return packages;
+  };
 
-  // Install module
-  fs.mkdirSync(targetModuleDir, { recursive: true });
-  fse.copySync(originModuleDir, targetModuleDir, { filter: filterMeta });
+  copy(originModuleDir, targetModuleDir);
 
-  // NPM specific step
-  find.file(originModuleDir, function(files) {
-    files.map(file => {
+  find.file(originModuleDir, function (files) {
+    files.map((file) => {
       if (path.basename(file) == "package.json") {
-        // Read package.json
         const packageJSON = JSON.parse(fs.readFileSync(file, "utf8"));
+        const yarnPath = path.join(
+          "file:.",
+          meta.root,
+          path.dirname(file).replace(originModuleDir, "")
+        );
+        let packages = [yarnPath, ...getDeps(packageJSON)];
 
-        const yarnPath = path.join("file:.", meta.root, path.dirname(file).replace(originModuleDir, ""));
-        let packages = [yarnPath];
-
-        // Install x-dependencies
-        if (packageJSON.hasOwnProperty("x-dependencies")) {
-          const deps = packageJSON["x-dependencies"];
-          for (const [key, value] of Object.entries(deps)) {
-            packages.push(`${key}@${value}`);
-          }
-        }
-
-        // Install packages
-        packages = packages.join(" ");
         process.chdir(demoDir);
-        execSync(`yarn add ${packages}`);
+        try {
+          execSync(`yarn add ${packages}`);
+        } catch (err) {
+          console.warn("Failed adding module. Is this module available?");
+        }
       }
     });
   });

--- a/scripts/add.js
+++ b/scripts/add.js
@@ -46,7 +46,7 @@ modules.map((module) => {
           meta.root,
           path.dirname(file).replace(originModuleDir, "")
         );
-        let packages = [yarnPath, ...getDeps(packageJSON)];
+        let packages = [yarnPath, ...getDeps(packageJSON)].join(" ");
 
         process.chdir(demoDir);
         try {


### PR DESCRIPTION
This PR updates the `remove.js` script to support any kind of module, by comparing
each file path to the meta root property and thus obtaining relative paths that
get removed one by one.

Closes #56 