### PR TITLE
Cleanup node_modules

### DIFF
--- a/scripts/add.js
+++ b/scripts/add.js
@@ -9,11 +9,13 @@ const modules = process.argv.slice(2);
 const cwd = process.cwd();
 const demoDir = path.join(process.cwd(), config.demo.directory);
 
-const filterMeta = (src, _) => path.basename(src) != "meta.json";
+const IGNORED_ENTRIES = ["meta.json", "node_modules"];
+
+const filterFiles = (src, _) => !IGNORED_ENTRIES.includes(path.basename(src));
 
 const copy = (origin, target) => {
   fs.mkdirSync(target, { recursive: true });
-  fse.copySync(origin, target, { filter: filterMeta });
+  fse.copySync(origin, target, { filter: filterFiles });
 };
 
 modules.map((module) => {
@@ -34,6 +36,10 @@ modules.map((module) => {
     }
     return packages;
   };
+
+  // cleanup node_modules
+  fs.rmdirSync(path.join(originModuleDir, "node_modules"), { recursive: true });
+  fs.rmdirSync(path.join(originModuleDir, "yarn.lock"), { recursive: true });
 
   copy(originModuleDir, targetModuleDir);
 

--- a/scripts/parse.js
+++ b/scripts/parse.js
@@ -5,32 +5,41 @@ import crypto from "crypto";
 
 const MODULES_DIR = path.join("modules");
 const OUTPUT_FILE = path.join(config.dist.directory, "modules.json");
-const ACCEPTED_EXTENSIONS = [".json", ".js", ".ts", ".jsx", ".tsx", ".md", ".py"];
-const META_FILE = ["meta.json"]
+const ACCEPTED_EXTENSIONS = [
+  ".json",
+  ".js",
+  ".ts",
+  ".jsx",
+  ".tsx",
+  ".md",
+  ".py",
+];
+const META_FILE = ["meta.json"];
 
-const parseModules = dir => {
-  const valid = message => {
+const parseModules = (dir) => {
+  const valid = (message) => {
     console.log(`${message} \u2705`);
-  }
+  };
 
-  const invalid = message => {
+  const invalid = (message) => {
     console.log(`${message} \u274C`);
-  }
+  };
 
-  const accepted = str => {
-    return ACCEPTED_EXTENSIONS.includes(path.extname(str))
-  }
+  const accepted = (str) => {
+    return ACCEPTED_EXTENSIONS.includes(path.extname(str));
+  };
 
-  const meta = str => {
-    return (path.basename(str) == META_FILE);
-  }
+  const meta = (str) => {
+    return path.basename(str) == META_FILE;
+  };
 
-  const checksum = str => crypto.createHash('md5').update(str, 'utf8').digest('hex')
+  const checksum = (str) =>
+    crypto.createHash("md5").update(str, "utf8").digest("hex");
 
   const parseModule = (moduleDir, callback) => {
     let entries = fs.readdirSync(moduleDir);
-    entries.map(entry => {
-      let entryPath = path.join(moduleDir, entry)
+    entries.map((entry) => {
+      let entryPath = path.join(moduleDir, entry);
       let stats = fs.statSync(entryPath);
       if (stats.isDirectory()) {
         parseModule(entryPath, callback);
@@ -40,13 +49,13 @@ const parseModules = dir => {
         callback(filePath, content, meta(entryPath));
       }
     });
-  }
+  };
 
   let data = {};
   let modules = fs.readdirSync(dir);
-  console.log("")
-  console.log("Parsing modules...", "\n")
-  modules.map(module => {
+  console.log("");
+  console.log("Parsing modules...", "\n");
+  modules.map((module) => {
     let hasMeta = false;
     let modulePath = path.join(dir, module);
     data[module] = {
@@ -54,15 +63,24 @@ const parseModules = dir => {
         title: module,
         description: "",
         slug: module,
-        options: { "x": 0, "y": 0, "domTree": "" },
-        setup: "To properly configure this module, follow the instructions given in README.md inside the module folder."
+        options: { x: 0, y: 0, domTree: "" },
+        setup:
+          "To properly configure this module, follow the instructions given in README.md inside the module folder.",
       },
-      files: {}
+      files: {},
     };
+    // cleanup node_modules
+    fs.rmdirSync(path.join(modulePath, "node_modules"), {
+      recursive: true,
+    });
+    fs.rmdirSync(path.join(modulePath, "yarn.lock"), { recursive: true });
     parseModule(modulePath, (filePath, content, meta = false) => {
       if (meta) {
-        hasMeta = true
-        data[module].meta = Object.assign(data[module].meta, JSON.parse(content));
+        hasMeta = true;
+        data[module].meta = Object.assign(
+          data[module].meta,
+          JSON.parse(content)
+        );
       } else {
         data[module].files[filePath] = content;
       }
@@ -85,13 +103,13 @@ const parseModules = dir => {
       }
     }
     if (isValid) {
-      valid("module passes all checks")
+      valid("module passes all checks");
     }
   });
-  console.log("")
+  console.log("");
   console.log("Total of modules:", Object.keys(data).length);
   return data;
-}
+};
 
 let data = parseModules(MODULES_DIR);
 fs.writeFileSync(OUTPUT_FILE, JSON.stringify(data, null, 2));

--- a/scripts/remove.js
+++ b/scripts/remove.js
@@ -1,5 +1,4 @@
 import fs from "fs";
-import fse from "fs-extra";
 import path from "path";
 import config from "./config.js";
 import find from "find";
@@ -9,7 +8,7 @@ const modules = process.argv.slice(2);
 const cwd = process.cwd();
 const demoDir = path.join(process.cwd(), config.demo.directory);
 
-modules.map(module => {
+modules.map((module) => {
   process.chdir(cwd);
   const originModuleDir = path.join(process.cwd(), "modules", module);
   const meta = JSON.parse(
@@ -20,8 +19,11 @@ modules.map(module => {
   const filterPackageJSON = (src, _) => path.basename(src) == "package.json";
   const filterMeta = (src, _) => path.basename(src) != "meta.json";
 
+  // cleanup node_modules
+  fs.rmdirSync(path.join(originModuleDir, "node_modules"), { recursive: true });
+  fs.rmdirSync(path.join(targetModuleDir, "node_modules"), { recursive: true });
 
-  find.file(originModuleDir, function(files) {
+  find.file(originModuleDir, function (files) {
     let file = files.filter(filterPackageJSON)[0];
     if (file) {
       const packageJSON = JSON.parse(fs.readFileSync(file, "utf8"));
@@ -31,12 +33,12 @@ modules.map(module => {
       try {
         execSync(`yarn remove ${name}`);
       } catch (err) {
-        console.warn("Failed removing module. Is this module installed?")
-        return
+        console.warn("Failed removing module. Is this module installed?");
+        return;
       }
     }
 
-    files.filter(filterMeta).map(file => {
+    files.filter(filterMeta).map((file) => {
       let targetFilePath = path.join(
         targetModuleDir,
         path.relative(originModuleDir, file)


### PR DESCRIPTION
This PR improves handling `node_modules` directories, removing them on `add`, `remove` and `parse` commands.