### PR TITLE
Restrict dependabot python updates to lockfile only

### DIFF
--- a/scaffold/template/custom/.github/dependabot.yml
+++ b/scaffold/template/custom/.github/dependabot.yml
@@ -14,3 +14,5 @@ updates:
       day: sunday
       time: "13:00"
     open-pull-requests-limit: 10
+    # Avoid major upgrades since they may not be compatible with the Crowdbotics ecosystem
+    versioning-strategy: lockfile-only


### PR DESCRIPTION
## Type of PR

- [ ] Bugfix
- [ ] New feature
- [X] Minor changes

## Changes introduced

Change dependabot updates for python to lockfile only. This should prevent major version changes.

This was already added to the web scaffold. [This app](https://github.com/crowdbotics-apps/dependabot2108102-d-22866/pulls) demonstrates that it works.

## Test and review

Generated apps should only get minor updates as specified in Pipfile.