### PR TITLE
Node.js v16.6.1 support

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "index.js",
   "type": "module",
   "engines": {
-    "node": ">14.0 <15.0"
+    "node": ">14.0"
   },
   "scripts": {
     "demo": "node scripts/demo.js",

--- a/scripts/add.js
+++ b/scripts/add.js
@@ -1,4 +1,4 @@
-import fs from "fs";
+import fs, { existsSync } from "fs";
 import fse from "fs-extra";
 import path from "path";
 import config from "./config.js";
@@ -38,12 +38,18 @@ modules.map((module) => {
   };
 
   // cleanup node_modules
-  fs.rmdirSync(path.join(originModuleDir, "node_modules"), { recursive: true });
-  fs.rmdirSync(path.join(originModuleDir, "yarn.lock"), { recursive: true });
+  if (existsSync(path.join(originModuleDir, "node_modules"))) {
+    fs.rmdirSync(path.join(originModuleDir, "node_modules"), {
+      recursive: true,
+    });
+  }
+  if (existsSync(path.join(originModuleDir, "yarn.lock"))) {
+    fs.rmdirSync(path.join(originModuleDir, "yarn.lock"), { recursive: true });
+  }
 
   copy(originModuleDir, targetModuleDir);
 
-  find.file(originModuleDir, function (files) {
+  find.file(originModuleDir, function(files) {
     files.map((file) => {
       if (path.basename(file) == "package.json") {
         const packageJSON = JSON.parse(fs.readFileSync(file, "utf8"));

--- a/scripts/parse.js
+++ b/scripts/parse.js
@@ -1,4 +1,4 @@
-import fs from "fs";
+import fs, { existsSync } from "fs";
 import path from "path";
 import config from "./config.js";
 import crypto from "crypto";
@@ -90,10 +90,14 @@ const parseModules = (dir) => {
     data[module] = moduleDefaults(module);
 
     // cleanup node_modules
-    fs.rmdirSync(path.join(modulePath, "node_modules"), {
-      recursive: true,
-    });
-    fs.rmdirSync(path.join(modulePath, "yarn.lock"), { recursive: true });
+    if (existsSync(path.join(modulePath, "node_modules"))) {
+      fs.rmdirSync(path.join(modulePath, "node_modules"), {
+        recursive: true,
+      });
+    }
+    if (existsSync(path.join(modulePath, "yarn.lock"))) {
+      fs.rmdirSync(path.join(modulePath, "yarn.lock"), { recursive: true });
+    }
 
     parseModule(modulePath, (filePath, content) => {
       data[module].files[filePath] = content;

--- a/scripts/remove.js
+++ b/scripts/remove.js
@@ -1,4 +1,4 @@
-import fs from "fs";
+import fs, { existsSync } from "fs";
 import path from "path";
 import config from "./config.js";
 import find from "find";
@@ -20,10 +20,16 @@ modules.map((module) => {
   const filterMeta = (src, _) => path.basename(src) != "meta.json";
 
   // cleanup node_modules
-  fs.rmdirSync(path.join(originModuleDir, "node_modules"), { recursive: true });
-  fs.rmdirSync(path.join(targetModuleDir, "node_modules"), { recursive: true });
+  if (existsSync(path.join(originModuleDir, "node_modules"))) {
+    fs.rmdirSync(path.join(originModuleDir, "node_modules"), {
+      recursive: true,
+    });
+  }
+  if (existsSync(path.join(targetModuleDir, "node_modules"))) {
+    fs.rmdirSync(path.join(targetModuleDir, "node_modules"), { recursive: true });
+  }
 
-  find.file(originModuleDir, function (files) {
+  find.file(originModuleDir, function(files) {
     let file = files.filter(filterPackageJSON)[0];
     if (file) {
       const packageJSON = JSON.parse(fs.readFileSync(file, "utf8"));


### PR DESCRIPTION
## Ticket

PLAT-XXXX
_Related tickets:_
_Related PRs:_

## Type of PR

- [ ] Bugfix
- [ ] New feature
- [x] Minor changes

## Changes introduced

This PR removes the Node.js version limit in the `engines` property of the `package.json` file.

It also adds `existsSync` checks for potentially missing directories.

## Test and review

The following test scenario should work.
```
nvm install 16.6.1 # or your node.js version manager of choice
yarn run bootstrap
yarn run add react-native-app-menu
yarn run remove react-native-app-menu
yarn run template
```
