### PR TITLE
Update Terms and Conditions for Module Options

### DIFF
--- a/modules/terms-and-conditions/backend/modules/terms_and_conditions/README.md
+++ b/modules/terms-and-conditions/backend/modules/terms_and_conditions/README.md
@@ -17,7 +17,7 @@
 1. Go to your admin panel to add a new `TermAndCondition` object: `<site-url>.botics.co/admin/modules/termandcondition/`. Make sure you save it.
 2. Make sure to set the active flag; without at least 1 `TermAndCondition` object with an active flag, nothing will be returned by the backend. If there are multiple terms objects with active flags, the most recently updated one will be returned.
 3. Your terms will be available at the following endpoint:
-GET: `<site-url>.botics.co/modules/terms/termsandconditions/`
+GET: `<site-url>.botics.co/modules/terms-and-conditions/`
 Example Response: 
 ```
 

--- a/modules/terms-and-conditions/backend/modules/terms_and_conditions/viewsets.py
+++ b/modules/terms-and-conditions/backend/modules/terms_and_conditions/viewsets.py
@@ -1,18 +1,23 @@
-from rest_framework import authentication, permissions
+from rest_framework import authentication
+from rest_framework.permissions import BasePermission, SAFE_METHODS, IsAdminUser
 from .models import TermAndCondition
 from .serializers import TermAndConditionSerializer
 from rest_framework import viewsets
 
 
+class ReadOnly(BasePermission):
+    def has_permission(self, request, view):
+        return request.method in SAFE_METHODS
+
 class TermAndConditionViewSet(viewsets.ModelViewSet):
     serializer_class = TermAndConditionSerializer
-    permission_classes = [permissions.AllowAny]
+    permission_classes = [IsAdminUser|ReadOnly] #Makes it Read-only unless admin
     authentication_classes = (
         authentication.SessionAuthentication,
         authentication.TokenAuthentication,
     )
 
-   	# This query will only return a single (if it exists) T&C string, and that will be 
-   	# the most recently updated one that *also* has an active flag. You must set at least
-   	# one T&C object to active for this to work.
+    # This query will only return a single (if it exists) T&C string, and that will be 
+    # the most recently updated one that *also* has an active flag. You must set at least
+    # one T&C object to active for this to work.
     queryset = TermAndCondition.objects.filter(is_active=True).order_by('-updated_at')[0:1]

--- a/modules/terms-and-conditions/modules/terms-and-conditions/README.md
+++ b/modules/terms-and-conditions/modules/terms-and-conditions/README.md
@@ -1,6 +1,6 @@
 # Terms & Conditions Screen
 
-The Terms and Conditions Screen is a React Native based screen that renders terms and conditions with a simple header.
+The Terms and Conditions Screen is a React Native based screen that renders a Terms and Conditions page with a simple header.
 
 ## Manual Setup
 
@@ -13,8 +13,8 @@ const { title, navigator } = TermsAndConditions;
 ```
 
 ## Configuring the Terms & Conditions Frontend
-All that is required to configure the frontend is to edit the url in `index.js` to point to your app's url on the web. On line 14 of `index.js`, replace <APP_URL_HERE> with your App's url (you can get this from the crowdbotics dashboard).
-`fetch('https://<APP_URL_HERE>.botics.co/modules/terms-and-conditions/')`
+All that is required to configure the frontend is to edit the url variable in `options.js` to point to your app's url on the web. 
+
 
 ## Contributing
 

--- a/modules/terms-and-conditions/modules/terms-and-conditions/README.md
+++ b/modules/terms-and-conditions/modules/terms-and-conditions/README.md
@@ -13,7 +13,16 @@ const { title, navigator } = TermsAndConditions;
 ```
 
 ## Configuring the Terms & Conditions Frontend
-All that is required to configure the frontend is to edit the url variable in `options.js` to point to your app's url on the web. 
+All that is required to configure the frontend is to edit the url variable in `options/options.js` to point to your app's url on the web. That url should have a trailing slash. 
+
+```
+export const globalOptions = {
+  name: "demoIdentifier",
+  url: "https://<your-app-url-here>.botics.co/",
+  api: "https://<your-app-url-here>.co/api/v1"
+}
+
+```
 
 
 ## Contributing

--- a/modules/terms-and-conditions/modules/terms-and-conditions/index.js
+++ b/modules/terms-and-conditions/modules/terms-and-conditions/index.js
@@ -1,17 +1,18 @@
-import React, { useEffect, useState } from 'react';
+import React, { useEffect, useState, useContext } from 'react';
+import { OptionsContext, GlobalOptionsContext } from "@options";
 import { Text, View, ScrollView, TouchableOpacity, useWindowDimensions } from 'react-native';
-import { styles } from './styles';
 import HTML from "react-native-render-html";
 
 
 const TermsAndConditions = ({ navigation }) => {
 
+  const options = useContext(OptionsContext);
   const contentWidth = useWindowDimensions().width;
-  const [htmlContent, setHtmlContent] = useState('<h1> No Terms and Conditions Loaded </h1>');
+  const [htmlContent, setHtmlContent] = useState('<h1>No Terms and Conditions Loaded</h1>');
   
   useEffect(() => {
-    //change the root url below to your project's url. 
-    fetch('https://<APP_URL_HERE>.botics.co/modules/terms/termsandconditions/')
+    //Set your API's URL via Module Options - in options.js
+    fetch(options.url)
       .then(response => response.json())
       .then(data => setHtmlContent(data[0]['body']))
       .catch(err => alert("Terms and Conditions could not be loaded at this time."));
@@ -19,21 +20,18 @@ const TermsAndConditions = ({ navigation }) => {
 
 
   return (
-    <View
-      style={{
-        flex: 1,
-      }}>
-      <View style={styles.heading}>
+    <View style={{flex: 1}}>
+      <View style={options.styles.heading}>
         <TouchableOpacity
-          style={ styles.touchableopacity}
+          style={options.styles.touchableopacity}
           onPress={() => {
             navigation.goBack();
           }}>
         </TouchableOpacity>
-        <Text style={styles.header}>TERMS AND CONDITIONS</Text>
+        <Text style={options.styles.header}>{options.title}</Text>
       </View>
-      <ScrollView style={{ flex: 1 }}>
-        <HTML source={{ html: htmlContent }} contentWidth={contentWidth} />
+      <ScrollView style={{flex: 1}}>
+        <HTML source={{html: htmlContent}} contentWidth={contentWidth} />
       </ScrollView>
     </View>
   );

--- a/modules/terms-and-conditions/modules/terms-and-conditions/index.js
+++ b/modules/terms-and-conditions/modules/terms-and-conditions/index.js
@@ -1,6 +1,6 @@
-import React, { useEffect, useState, useContext } from 'react';
+import React, { useEffect, useState, useContext } from "react";
 import { OptionsContext, GlobalOptionsContext } from "@options";
-import { Text, View, ScrollView, TouchableOpacity, useWindowDimensions } from 'react-native';
+import { Text, View, ScrollView, TouchableOpacity, useWindowDimensions } from "react-native";
 import HTML from "react-native-render-html";
 
 
@@ -8,14 +8,14 @@ const TermsAndConditions = ({ navigation }) => {
 
   const options = useContext(OptionsContext);
   const contentWidth = useWindowDimensions().width;
-  const [htmlContent, setHtmlContent] = useState('<h1>No Terms and Conditions Loaded</h1>');
+  const [htmlContent, setHtmlContent] = useState("<h1>Loading...</h1>");
   
   useEffect(() => {
     //Set your API's URL via Module Options - in options.js
     fetch(options.url)
       .then(response => response.json())
       .then(data => setHtmlContent(data[0]['body']))
-      .catch(err => alert("Terms and Conditions could not be loaded at this time."));
+      .catch(err => setHtmlContent("<h1>Error Loading Terms and Conditions</h1>"));
   });
 
 

--- a/modules/terms-and-conditions/modules/terms-and-conditions/index.js
+++ b/modules/terms-and-conditions/modules/terms-and-conditions/index.js
@@ -7,19 +7,19 @@ import HTML from "react-native-render-html";
 const TermsAndConditions = ({ navigation }) => {
 
   const options = useContext(OptionsContext);
+  const globalOptions = useContext(GlobalOptionsContext);
   const contentWidth = useWindowDimensions().width;
   const [htmlContent, setHtmlContent] = useState("<h1>Loading...</h1>");
   
   useEffect(() => {
     //Set your API's URL via Module Options - in options.js
-    fetch(options.url)
+    fetch(globalOptions.url + options.path)
       .then(response => response.json())
       .then(data => setHtmlContent(data[0]['body']))
       .catch(err => setHtmlContent("<h1>Error Loading Terms and Conditions</h1>"));
   });
 
-
-  return (
+  return (  
     <View style={{flex: 1}}>
       <View style={options.styles.heading}>
         <TouchableOpacity

--- a/modules/terms-and-conditions/modules/terms-and-conditions/options.js
+++ b/modules/terms-and-conditions/modules/terms-and-conditions/options.js
@@ -1,0 +1,35 @@
+import { StyleSheet } from "react-native";
+
+//Add your Backend's URL here. 
+const url = "https://<your-app-url>.botics.co/modules/terms-and-conditions/";
+
+
+const title = "Terms And Conditions";
+
+const styles = StyleSheet.create({
+  heading: {
+    height: 60,
+    backgroundColor: '#333333',
+    justifyContent: 'space-between',
+    padding: 20,
+    alignItems: 'flex-end',
+    flexDirection: 'row',
+    justifyContent:'center',
+
+  },
+  text: {
+    color: '#000000',
+    fontSize: 16,
+    width: '100%',
+  },
+  icon: { width: 18, height: 16 },
+  touchableopacity: { padding: 5 },
+  scrollview: { flex: 1, padding: 20 },
+  header: { color: '#fff', fontSize: 16, },
+});
+
+export default {
+  title: title,
+  url: url,
+  styles: styles,
+};

--- a/modules/terms-and-conditions/modules/terms-and-conditions/options.js
+++ b/modules/terms-and-conditions/modules/terms-and-conditions/options.js
@@ -1,7 +1,7 @@
 import { StyleSheet } from "react-native";
 
 //Add your Backend's URL here. 
-const url = "https://<your-app-url>.botics.co/modules/terms-and-conditions/";
+const url = "https://toc-1-29797.botics.co/modules/terms-and-conditions/";
 
 
 const title = "Terms And Conditions";
@@ -9,23 +9,23 @@ const title = "Terms And Conditions";
 const styles = StyleSheet.create({
   heading: {
     height: 60,
-    backgroundColor: '#333333',
-    justifyContent: 'space-between',
+    backgroundColor: "#333333",
+    justifyContent: "space-between",
     padding: 20,
-    alignItems: 'flex-end',
-    flexDirection: 'row',
-    justifyContent:'center',
+    alignItems: "flex-end",
+    flexDirection: "row",
+    justifyContent:"center",
 
   },
   text: {
-    color: '#000000',
+    color: "#000000",
     fontSize: 16,
-    width: '100%',
+    width: "100%",
   },
   icon: { width: 18, height: 16 },
   touchableopacity: { padding: 5 },
   scrollview: { flex: 1, padding: 20 },
-  header: { color: '#fff', fontSize: 16, },
+  header: { color: "#fff", fontSize: 16, },
 });
 
 export default {

--- a/modules/terms-and-conditions/modules/terms-and-conditions/options.js
+++ b/modules/terms-and-conditions/modules/terms-and-conditions/options.js
@@ -1,8 +1,7 @@
 import { StyleSheet } from "react-native";
 
-//Add your Backend's URL here. 
-const url = "https://toc-1-29797.botics.co/modules/terms-and-conditions/";
-
+//to configure this module, edit the base url in options/options.js
+const path = "/modules/terms-and-conditions/";
 
 const title = "Terms And Conditions";
 
@@ -30,6 +29,6 @@ const styles = StyleSheet.create({
 
 export default {
   title: title,
-  url: url,
+  path: path,
   styles: styles,
 };


### PR DESCRIPTION
## Ticket

PLAT-XXXX
N/A

## Type of PR

- [ ] Bugfix
- [x] New feature
- [] Minor changes

## Changes introduced

This adds support for using Module Options in the Terms and Condition module. Before, to use the module, a user would need to edit the code in `index.js` to point to an endpoint on their production server. Now they can now edit this value with module options - in the new `options.js` file. Once the UI goes live, this should make configuring this module require virtually no technical experience: A user simply adds the module via the storyboard, copy and pastes their production URL into the module options UI, and then uses the admin panel to add their Terms and Conditions.

## Test and review
Aside from normal review, I would test by spinning up a demo project, adding the terms and conditions module using the `npm run add` command and then setting the url in `options.js` to point to an API endpoint which is also set up with the Terms and Conditions module. I have one here: https://toc-1-29797.botics.co/modules/terms-and-conditions/
