### PR TITLE
Options Types - Add types to terms-and-conditions

### DIFF
--- a/modules/terms-and-conditions/meta.json
+++ b/modules/terms-and-conditions/meta.json
@@ -1,6 +1,17 @@
 {
   "title": "Terms and Conditions",
   "description": "Terms and Conditions screen",
-  "root": "/"
-
+  "root": "/",
+  "schema": {
+    "title": {
+      "type": "string",
+      "minLength": 3,
+      "pattern": "^[A-Z]"
+    },
+    "path": {
+      "type": "string",
+      "minLength": 1,
+      "format": "uri-reference"
+    }
+  }
 }


### PR DESCRIPTION
## Ticket

PLAT-5695
_Related tickets:_
_Related PRs:_ #128

## Type of PR

- [ ] Bugfix
- [x] New feature
- [ ] Minor changes

## Changes introduced

Adds types schema to the Terms and Conditions module.

Notice the format validation in `path`. It will only accept full or relative URIs.

Valid example:
```
/terms-and-conditions
```

Invalid example:
```
/terms and conditions
```

## Test and review

`yarn run parse` should run successfully.