### PR TITLE
PLAT-6341: xcode version changed to 13.0.0

### DIFF
--- a/scaffold/template/custom/.circleci/generate_mobile_config.sh
+++ b/scaffold/template/custom/.circleci/generate_mobile_config.sh
@@ -1,4 +1,4 @@
-#!/bin/bash 
+#!/bin/bash
 set -o pipefail
 
 mkdir configs/
@@ -136,7 +136,7 @@ jobs:
 
   ios:
     macos:
-      xcode: "11.1.0"
+      xcode: "13.0.0"
     working_directory: ~/build
 
     # use a --login shell so our "set Ruby version" command gets picked up for later steps


### PR DESCRIPTION
## Ticket

PLAT-6341

## Type of PR

- [ ] Bugfix
- [ ] New feature
- [X] Minor changes

## Changes introduced

- _xcode version changed to 13.0.0 for support in circleci_

## Test and review

1. _Create react native app in [crowdbotics-slack-dev](https://crowdbotics-slack-dev.herokuapp.com/)_
2. _Make sure plan for app is paid one because IOS build will be made only for paid apps_
3. _Deploy mobile app_
4. _IOS build successful message should appear in `Activity` section of `App Activity`_
