### PR TITLE
PLAT-6341: config file generated for cookiecutter with updated xcode version

### DIFF
--- a/dist/cookie/{{cookiecutter.project_slug}}/.circleci/generate_mobile_config.sh
+++ b/dist/cookie/{{cookiecutter.project_slug}}/.circleci/generate_mobile_config.sh
@@ -1,4 +1,4 @@
-#!/bin/bash 
+#!/bin/bash
 set -o pipefail
 
 mkdir configs/
@@ -136,7 +136,7 @@ jobs:
 
   ios:
     macos:
-      xcode: "11.1.0"
+      xcode: "13.0.0"
     working_directory: ~/build
 
     # use a --login shell so our "set Ruby version" command gets picked up for later steps

--- a/dist/raw/ProjectName/.circleci/generate_mobile_config.sh
+++ b/dist/raw/ProjectName/.circleci/generate_mobile_config.sh
@@ -1,4 +1,4 @@
-#!/bin/bash 
+#!/bin/bash
 set -o pipefail
 
 mkdir configs/
@@ -136,7 +136,7 @@ jobs:
 
   ios:
     macos:
-      xcode: "11.1.0"
+      xcode: "13.0.0"
     working_directory: ~/build
 
     # use a --login shell so our "set Ruby version" command gets picked up for later steps

--- a/scaffold/template/custom/.circleci/generate_mobile_config.sh
+++ b/scaffold/template/custom/.circleci/generate_mobile_config.sh
@@ -1,4 +1,4 @@
-#!/bin/bash 
+#!/bin/bash
 set -o pipefail
 
 mkdir configs/
@@ -136,7 +136,7 @@ jobs:
 
   ios:
     macos:
-      xcode: "11.1.0"
+      xcode: "13.0.0"
     working_directory: ~/build
 
     # use a --login shell so our "set Ruby version" command gets picked up for later steps


### PR DESCRIPTION
## Ticket

PLAT-6341

## Type of PR

- [ ] Bugfix
- [X] New feature
- [ ] Minor changes

## Changes introduced

_`generate_mobile_config.sh` file changed in cookiecutter to update xcode version to `13.0.0`_

## Test and review
