### PR TITLE
Add ts and tsx to metro resolver extensions

### DIFF
--- a/dist/cookie/{{cookiecutter.project_slug}}/metro.config.js
+++ b/dist/cookie/{{cookiecutter.project_slug}}/metro.config.js
@@ -26,7 +26,7 @@ module.exports = {
     })
   },
   resolver: {
-    sourceExts: ["js", "jsx"],
+    sourceExts: ["js", "jsx", "ts", "tsx"],
     extraNodeModules: new Proxy(extraNodeModules, {
       get: (target, name) =>
         //redirects dependencies referenced from extraNodeModules to local node_modules

--- a/dist/cookie/{{cookiecutter.project_slug}}/yarn.lock
+++ b/dist/cookie/{{cookiecutter.project_slug}}/yarn.lock
@@ -1358,9 +1358,9 @@
     redux "^4.0.0"
 
 "@types/react@*":
-  version "18.0.6"
-  resolved "https://registry.yarnpkg.com/@types/react/-/react-18.0.6.tgz#30206c3830af6ce8639b91ace5868bc2d3d1d96c"
-  integrity sha512-bPqwzJRzKtfI0mVYr5R+1o9BOE8UEXefwc1LwcBtfnaAn6OoqMhLa/91VA8aeWfDPJt1kHvYKI8RHcQybZLHHA==
+  version "18.0.7"
+  resolved "https://registry.yarnpkg.com/@types/react/-/react-18.0.7.tgz#8437a226763adf854969954dfe582529a406cbad"
+  integrity sha512-CXSXHzTexlX9esf4ReIUJeaemKcmBEvYzxHDUk19c3BCcEGUvUjkeC3jkscPSfSaQ6SPDRNd/zMxi8oc/P1zxA==
   dependencies:
     "@types/prop-types" "*"
     "@types/scheduler" "*"

--- a/dist/raw/ProjectName/metro.config.js
+++ b/dist/raw/ProjectName/metro.config.js
@@ -26,7 +26,7 @@ module.exports = {
     })
   },
   resolver: {
-    sourceExts: ["js", "jsx"],
+    sourceExts: ["js", "jsx", "ts", "tsx"],
     extraNodeModules: new Proxy(extraNodeModules, {
       get: (target, name) =>
         //redirects dependencies referenced from extraNodeModules to local node_modules

--- a/dist/raw/ProjectName/yarn.lock
+++ b/dist/raw/ProjectName/yarn.lock
@@ -1358,9 +1358,9 @@
     redux "^4.0.0"
 
 "@types/react@*":
-  version "18.0.6"
-  resolved "https://registry.yarnpkg.com/@types/react/-/react-18.0.6.tgz#30206c3830af6ce8639b91ace5868bc2d3d1d96c"
-  integrity sha512-bPqwzJRzKtfI0mVYr5R+1o9BOE8UEXefwc1LwcBtfnaAn6OoqMhLa/91VA8aeWfDPJt1kHvYKI8RHcQybZLHHA==
+  version "18.0.7"
+  resolved "https://registry.yarnpkg.com/@types/react/-/react-18.0.7.tgz#8437a226763adf854969954dfe582529a406cbad"
+  integrity sha512-CXSXHzTexlX9esf4ReIUJeaemKcmBEvYzxHDUk19c3BCcEGUvUjkeC3jkscPSfSaQ6SPDRNd/zMxi8oc/P1zxA==
   dependencies:
     "@types/prop-types" "*"
     "@types/scheduler" "*"

--- a/scaffold/template/custom/metro.config.js
+++ b/scaffold/template/custom/metro.config.js
@@ -26,7 +26,7 @@ module.exports = {
     })
   },
   resolver: {
-    sourceExts: ["js", "jsx"],
+    sourceExts: ["js", "jsx", "ts", "tsx"],
     extraNodeModules: new Proxy(extraNodeModules, {
       get: (target, name) =>
         //redirects dependencies referenced from extraNodeModules to local node_modules


### PR DESCRIPTION
## Ticket

_Related tickets:_
_Related PRs:_

## Type of PR

- [ ] Bugfix
- [x] New feature
- [ ] Minor changes

## Changes introduced

This PR adds support for `.ts` `.tsx` file extensions. Builds can fail when trying to resolve navigation libraries that depend on those extensions.

## Test and review

Run a demo app, it should build successfully.