### PR TITLE
Hotfix: Favor native library over 3rd party for TouchableOpacity in screen

### DIFF
--- a/modules/screen-login/index.js
+++ b/modules/screen-login/index.js
@@ -1,6 +1,5 @@
 import React from "react";
-import { Text, StyleSheet, Dimensions, View } from "react-native";
-import { TouchableOpacity } from "react-native-gesture-handler";
+import { Text, StyleSheet, Dimensions, View, TouchableOpacity } from "react-native";
 
 const deviceWidth = Dimensions.get("window").width;
 


### PR DESCRIPTION
## Ticket

N/A

## Type of PR

- [ ] Bugfix
- [ ] New feature
- [x] Minor changes

## Changes introduced
Using the native API instead of `react-native-gesture-handler `for login screen. You can test the code on snack and you will see that they behave the same: https://snack.expo.dev/@alinetavares/touchableopacity

## Test and review
Resulting screen rendering and behavior should not change