### PR TITLE
Update payments module

### DIFF
--- a/modules/payments/backend/modules/payments/payments/services/StripeService.py
+++ b/modules/payments/backend/modules/payments/payments/services/StripeService.py
@@ -3,8 +3,9 @@ import environ
 
 env = environ.Env()
 
+
 class StripeService:
-    stripe.api_key = env.str("STRIPE_SECRET_KEY")
+    stripe.api_key = env.str("STRIPE_SECRET_KEY", "")
 
     @classmethod
     def create_payment_intent_sheet(cls, cus_id, cents):


### PR DESCRIPTION
- Add default value to stripe.api_key to fix operations while is not
  yet configured

(Out-of-Ticket)

## Type of PR

- [x] Bugfix
- [ ] New feature
- [ ] Minor changes

## Changes introduced

Once payments is installed, it requires to set the env var STRIPE_API_KEY. While it is not set, operations will fail (like uninstalling, model builder, etc.). Provide a default for the var to prevent that.

Spotted here: https://github.com/crowdbotics/crowdbotics-slack-app/pull/3641

## Test and review

Install and uninstall the payments module