### PR TITLE
test ignore-path=.eslintignore

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -15,8 +15,8 @@ jobs:
           node-version: 16
           cache: "yarn"
       - run: yarn install
-      - uses: crowdbotics/action-eslint@v2.2.1
+      - uses: sibiraj-s/action-eslint@v2.1.1
         with:
-          eslint-args: "--config .eslintrc.json --ignore-path=.gitignore --quiet"
+          eslint-args: "--config .eslintrc.json --ignore-path=.eslintignore --quiet"
           extensions: "js,jsx,ts,tsx"
           annotations: true

--- a/dist/raw/ProjectName/index.js
+++ b/dist/raw/ProjectName/index.js
@@ -2,8 +2,8 @@
  * @format
  */
 
-import {AppRegistry} from 'react-native';
-import App from './App';
-import {name as appName} from './app.json';
+import { AppRegistry } from "react-native"
+import App from "./App"
+import { name as appName } from "./app.json"
 
-AppRegistry.registerComponent(appName, () => App);
+AppRegistry.registerComponent(appName, () => App)


### PR DESCRIPTION
This draft PR showcases that ignoring a path with `.eslintignore` still tries to load a sibling `.eslintrc.js` file present in the path.

This happens due to the ESLint's [configuration cascading](https://eslint.org/docs/latest/user-guide/configuring/configuration-files#cascading-and-hierarchy) feature.
