### PR TITLE
Remove variable reference in option.js stylesheet

### DIFF
--- a/modules/faq/modules/faq/options.js
+++ b/modules/faq/modules/faq/options.js
@@ -35,13 +35,13 @@ const styles = StyleSheet.create({
   searchSection: {
     flexDirection: "row",
     alignItems: "center",
-    backgroundColor: colors.whiteSmoke,
+    backgroundColor: "#F6F6F6",
     padding: 10,
     borderRadius: 10
   },
   searchIcon: { width: 25, height: 20, marginEnd: 5 },
   input: {
-    color: colors.black,
+    color: "#000000",
     fontSize: 16
   },
   list: { marginTop: 10 }


### PR DESCRIPTION
## Type of PR

- [x] Bugfix

## Changes introduced

Removes the color reference and replaces it with the string value. This enables this module options to be parsed once again (parser doesn't handle following references/bindings).

## Test and review

Options parsing should work for this module.