### PR TITLE
PLAT-9711 - Hotfix: App Menu options styles syntax

### DIFF
--- a/modules/react-native-app-menu/options.js
+++ b/modules/react-native-app-menu/options.js
@@ -1,10 +1,9 @@
-import { StyleSheet, StatusBar } from "react-native";
+import { StyleSheet } from "react-native";
 
 const styles = StyleSheet.create({
   container: {
     flex: 1,
-    padding: 13,
-    paddingTop: StatusBar.currentHeight
+    padding: 13
   },
   hr: {
     marginTop: 20,


### PR DESCRIPTION
## Ticket

PLAT-9711

## Type of PR

- [x] Bugfix

## Review checklist for new or updated modules

- [x] I updated the modules build (`/dist` directory) with `yarn run dist`

React Native modules specific checks:

- [x] `yarn run demo` and `yarn run add app-menu <your-module>` runs correctly

## Review checklist for scaffold changes

- [x] I have made no scaffold changes

## Changes introduced

Removes the use of `StatusBar` for setting the padding top value. Options parser doesn't support this syntax yet.

## Test and review

N/A
