### PR TITLE
Fix - Fix web build issues with node_modules on ESM format

### DIFF
--- a/config.js
+++ b/config.js
@@ -75,6 +75,18 @@ export default {
           "ios/fastlane/metadata/review_information/review_demo_user.txt"
         ],
         upgradeManifestImport: "./manifest/200-to-210.json"
+      },
+      {
+        text: "Upgrade my scaffold (2.1.0 -> 2.1.1)",
+        previousVersion: "2.1.0",
+        previousVersionSHA: "03d0e48891aaf96bd0f2653ac1f7b0950f2c6289",
+        nextVersion: "2.1.1",
+        nextVersionSHA: "fix/web-build-babel-config",
+        ignoreTemplatize: [
+          "ios/fastlane/metadata/review_information/review_demo_password.txt",
+          "ios/fastlane/metadata/review_information/review_demo_user.txt"
+        ],
+        upgradeManifestImport: "./manifest/210-to-211.json"
       }
     ],
     manifest: {

--- a/dist/cookie/{{cookiecutter.project_slug}}/.crowdbotics.json
+++ b/dist/cookie/{{cookiecutter.project_slug}}/.crowdbotics.json
@@ -1,7 +1,7 @@
 {
   "scaffold": {
     "type": "react-native",
-    "version": "2.1.0",
+    "version": "2.1.1",
     "cookiecutter_context": {
       "project_name": "{{cookiecutter.project_name}}",
       "project_slug": "{{cookiecutter.project_slug}}",

--- a/dist/cookie/{{cookiecutter.project_slug}}/webpack.config.js
+++ b/dist/cookie/{{cookiecutter.project_slug}}/webpack.config.js
@@ -69,9 +69,8 @@ const babelLoaderConfiguration = {
     path.resolve(appDirectory, "screens"),
     path.resolve(appDirectory, "options"),
     path.resolve(appDirectory, "store"),
-    path.resolve(appDirectory, "node_modules")
+    path.resolve(appDirectory, "node_modules/react-native-reanimated")
   ],
-  exclude: [path.resolve(appDirectory, "node_modules/@babel")],
   use: {
     loader: "babel-loader",
     options: babelOptions

--- a/manifest/210-to-211.json
+++ b/manifest/210-to-211.json
@@ -1,0 +1,630 @@
+[
+  {
+    "path": ".bundle/config",
+    "type": "text"
+  },
+  {
+    "path": ".circleci/config.yml",
+    "type": "text"
+  },
+  {
+    "path": ".circleci/generate_mobile_android_config.sh",
+    "type": "text"
+  },
+  {
+    "path": ".circleci/generate_mobile_ios_config.sh",
+    "type": "text"
+  },
+  {
+    "path": ".circleci/webhook_callback.sh",
+    "type": "text"
+  },
+  {
+    "path": ".crowdbotics.json",
+    "type": "json"
+  },
+  {
+    "path": ".env.template",
+    "type": "text"
+  },
+  {
+    "path": ".eslintrc.js",
+    "type": "babel"
+  },
+  {
+    "path": ".github/.keep",
+    "type": "text"
+  },
+  {
+    "path": ".gitignore",
+    "type": "text"
+  },
+  {
+    "path": ".node-version",
+    "type": "text"
+  },
+  {
+    "path": ".prettierrc.js",
+    "type": "babel"
+  },
+  {
+    "path": ".watchmanconfig",
+    "type": "text"
+  },
+  {
+    "path": "App.js",
+    "type": "babel"
+  },
+  {
+    "path": "Dockerfile",
+    "type": "text"
+  },
+  {
+    "path": "Gemfile",
+    "type": "text"
+  },
+  {
+    "path": "Gemfile.lock",
+    "type": "text"
+  },
+  {
+    "path": "README.md",
+    "type": "text"
+  },
+  {
+    "path": "__tests__/App-test.tsx",
+    "type": "babel"
+  },
+  {
+    "path": "android/app/build.gradle",
+    "type": "text"
+  },
+  {
+    "path": "android/app/debug.keystore",
+    "type": "text"
+  },
+  {
+    "path": "android/app/proguard-rules.pro",
+    "type": "text"
+  },
+  {
+    "path": "android/app/src/debug/AndroidManifest.xml",
+    "type": "text"
+  },
+  {
+    "path": "android/app/src/debug/java/com/{{slug}}/ReactNativeFlipper.java",
+    "type": "text"
+  },
+  {
+    "path": "android/app/src/main/AndroidManifest.xml",
+    "type": "text"
+  },
+  {
+    "path": "android/app/src/main/java/com/{{slug}}/MainActivity.java",
+    "type": "text"
+  },
+  {
+    "path": "android/app/src/main/java/com/{{slug}}/MainApplication.java",
+    "type": "text"
+  },
+  {
+    "path": "android/app/src/main/res/drawable/rn_edit_text_material.xml",
+    "type": "text"
+  },
+  {
+    "path": "android/app/src/main/res/mipmap-hdpi/ic_launcher.png",
+    "type": "text"
+  },
+  {
+    "path": "android/app/src/main/res/mipmap-hdpi/ic_launcher_foreground.png",
+    "type": "text"
+  },
+  {
+    "path": "android/app/src/main/res/mipmap-hdpi/ic_launcher_round.png",
+    "type": "text"
+  },
+  {
+    "path": "android/app/src/main/res/mipmap-mdpi/ic_launcher.png",
+    "type": "text"
+  },
+  {
+    "path": "android/app/src/main/res/mipmap-mdpi/ic_launcher_foreground.png",
+    "type": "text"
+  },
+  {
+    "path": "android/app/src/main/res/mipmap-mdpi/ic_launcher_round.png",
+    "type": "text"
+  },
+  {
+    "path": "android/app/src/main/res/mipmap-xhdpi/ic_launcher.png",
+    "type": "text"
+  },
+  {
+    "path": "android/app/src/main/res/mipmap-xhdpi/ic_launcher_foreground.png",
+    "type": "text"
+  },
+  {
+    "path": "android/app/src/main/res/mipmap-xhdpi/ic_launcher_round.png",
+    "type": "text"
+  },
+  {
+    "path": "android/app/src/main/res/mipmap-xxhdpi/ic_launcher.png",
+    "type": "text"
+  },
+  {
+    "path": "android/app/src/main/res/mipmap-xxhdpi/ic_launcher_foreground.png",
+    "type": "text"
+  },
+  {
+    "path": "android/app/src/main/res/mipmap-xxhdpi/ic_launcher_round.png",
+    "type": "text"
+  },
+  {
+    "path": "android/app/src/main/res/mipmap-xxxhdpi/ic_launcher.png",
+    "type": "text"
+  },
+  {
+    "path": "android/app/src/main/res/mipmap-xxxhdpi/ic_launcher_foreground.png",
+    "type": "text"
+  },
+  {
+    "path": "android/app/src/main/res/mipmap-xxxhdpi/ic_launcher_round.png",
+    "type": "text"
+  },
+  {
+    "path": "android/app/src/main/res/values/strings.xml",
+    "type": "text"
+  },
+  {
+    "path": "android/app/src/main/res/values/styles.xml",
+    "type": "text"
+  },
+  {
+    "path": "android/app/src/release/java/com/{{slug}}/ReactNativeFlipper.java",
+    "type": "text"
+  },
+  {
+    "path": "android/build.gradle",
+    "type": "text"
+  },
+  {
+    "path": "android/fastlane/Appfile",
+    "type": "text"
+  },
+  {
+    "path": "android/fastlane/Fastfile",
+    "type": "text"
+  },
+  {
+    "path": "android/fastlane/Pluginfile",
+    "type": "text"
+  },
+  {
+    "path": "android/fastlane/README.md",
+    "type": "text"
+  },
+  {
+    "path": "android/fastlane/metadata/android/en-US/images/phoneScreenshots/android-landscape.jpg",
+    "type": "text"
+  },
+  {
+    "path": "android/fastlane/metadata/android/en-US/images/phoneScreenshots/android-screenshot.jpg",
+    "type": "text"
+  },
+  {
+    "path": "android/fastlane/metadata/android/en-US/images/phoneScreenshots/wear-os.jpg",
+    "type": "text"
+  },
+  {
+    "path": "android/fastlane/metadata/android/en-US/title.txt",
+    "type": "text"
+  },
+  {
+    "path": "android/gradle/wrapper/gradle-wrapper.jar",
+    "type": "text"
+  },
+  {
+    "path": "android/gradle/wrapper/gradle-wrapper.properties",
+    "type": "text"
+  },
+  {
+    "path": "android/gradle.properties",
+    "type": "text"
+  },
+  {
+    "path": "android/gradlew",
+    "type": "text"
+  },
+  {
+    "path": "android/gradlew.bat",
+    "type": "text"
+  },
+  {
+    "path": "android/settings.gradle",
+    "type": "text"
+  },
+  {
+    "path": "app.json",
+    "type": "json"
+  },
+  {
+    "path": "babel.config.js",
+    "type": "babel"
+  },
+  {
+    "path": "heroku.yml",
+    "type": "text"
+  },
+  {
+    "path": "index.js",
+    "type": "babel"
+  },
+  {
+    "path": "ios/.xcode.env",
+    "type": "text"
+  },
+  {
+    "path": "ios/Podfile",
+    "type": "text"
+  },
+  {
+    "path": "ios/Podfile.lock",
+    "type": "text"
+  },
+  {
+    "path": "ios/Pods/Manifest.lock",
+    "type": "text"
+  },
+  {
+    "path": "ios/{{slug}}/AppDelegate.h",
+    "type": "text"
+  },
+  {
+    "path": "ios/{{slug}}/AppDelegate.mm",
+    "type": "text"
+  },
+  {
+    "path": "ios/{{slug}}/Images.xcassets/AppIcon.appiconset/Contents.json",
+    "type": "json"
+  },
+  {
+    "path": "ios/{{slug}}/Images.xcassets/AppIcon.appiconset/Icon-App-20x20@1x.png",
+    "type": "text"
+  },
+  {
+    "path": "ios/{{slug}}/Images.xcassets/AppIcon.appiconset/Icon-App-20x20@2x.png",
+    "type": "text"
+  },
+  {
+    "path": "ios/{{slug}}/Images.xcassets/AppIcon.appiconset/Icon-App-20x20@3x.png",
+    "type": "text"
+  },
+  {
+    "path": "ios/{{slug}}/Images.xcassets/AppIcon.appiconset/Icon-App-29x29@1x.png",
+    "type": "text"
+  },
+  {
+    "path": "ios/{{slug}}/Images.xcassets/AppIcon.appiconset/Icon-App-29x29@2x.png",
+    "type": "text"
+  },
+  {
+    "path": "ios/{{slug}}/Images.xcassets/AppIcon.appiconset/Icon-App-29x29@3x.png",
+    "type": "text"
+  },
+  {
+    "path": "ios/{{slug}}/Images.xcassets/AppIcon.appiconset/Icon-App-40x40@1x.png",
+    "type": "text"
+  },
+  {
+    "path": "ios/{{slug}}/Images.xcassets/AppIcon.appiconset/Icon-App-40x40@2x.png",
+    "type": "text"
+  },
+  {
+    "path": "ios/{{slug}}/Images.xcassets/AppIcon.appiconset/Icon-App-40x40@3x.png",
+    "type": "text"
+  },
+  {
+    "path": "ios/{{slug}}/Images.xcassets/AppIcon.appiconset/Icon-App-60x60@2x.png",
+    "type": "text"
+  },
+  {
+    "path": "ios/{{slug}}/Images.xcassets/AppIcon.appiconset/Icon-App-60x60@3x.png",
+    "type": "text"
+  },
+  {
+    "path": "ios/{{slug}}/Images.xcassets/AppIcon.appiconset/Icon-App-76x76@1x.png",
+    "type": "text"
+  },
+  {
+    "path": "ios/{{slug}}/Images.xcassets/AppIcon.appiconset/Icon-App-76x76@2x.png",
+    "type": "text"
+  },
+  {
+    "path": "ios/{{slug}}/Images.xcassets/AppIcon.appiconset/Icon-App-83.5x83.5@2x.png",
+    "type": "text"
+  },
+  {
+    "path": "ios/{{slug}}/Images.xcassets/AppIcon.appiconset/ItunesArtwork@2x.png",
+    "type": "text"
+  },
+  {
+    "path": "ios/{{slug}}/Images.xcassets/Contents.json",
+    "type": "json"
+  },
+  {
+    "path": "ios/{{slug}}/Info.plist",
+    "type": "text"
+  },
+  {
+    "path": "ios/{{slug}}/LaunchScreen.storyboard",
+    "type": "text"
+  },
+  {
+    "path": "ios/{{slug}}/main.m",
+    "type": "text"
+  },
+  {
+    "path": "ios/{{slug}}.xcodeproj/project.pbxproj",
+    "type": "text"
+  },
+  {
+    "path": "ios/{{slug}}.xcodeproj/xcshareddata/xcschemes/{{slug}}.xcscheme",
+    "type": "text"
+  },
+  {
+    "path": "ios/{{slug}}.xcworkspace/contents.xcworkspacedata",
+    "type": "text"
+  },
+  {
+    "path": "ios/{{slug}}Tests/Info.plist",
+    "type": "text"
+  },
+  {
+    "path": "ios/{{slug}}Tests/{{slug}}Tests.m",
+    "type": "text"
+  },
+  {
+    "path": "ios/fastlane/Appfile",
+    "type": "text"
+  },
+  {
+    "path": "ios/fastlane/Deliverfile",
+    "type": "text"
+  },
+  {
+    "path": "ios/fastlane/Fastfile",
+    "type": "text"
+  },
+  {
+    "path": "ios/fastlane/Matchfile",
+    "type": "text"
+  },
+  {
+    "path": "ios/fastlane/README.md",
+    "type": "text"
+  },
+  {
+    "path": "ios/fastlane/metadata/app_rating_config.json",
+    "type": "json"
+  },
+  {
+    "path": "ios/fastlane/metadata/copyright.txt",
+    "type": "text"
+  },
+  {
+    "path": "ios/fastlane/metadata/en-US/apple_tv_privacy_policy.txt",
+    "type": "text"
+  },
+  {
+    "path": "ios/fastlane/metadata/en-US/description.txt",
+    "type": "text"
+  },
+  {
+    "path": "ios/fastlane/metadata/en-US/keywords.txt",
+    "type": "text"
+  },
+  {
+    "path": "ios/fastlane/metadata/en-US/marketing_url.txt",
+    "type": "text"
+  },
+  {
+    "path": "ios/fastlane/metadata/en-US/name.txt",
+    "type": "text"
+  },
+  {
+    "path": "ios/fastlane/metadata/en-US/privacy_url.txt",
+    "type": "text"
+  },
+  {
+    "path": "ios/fastlane/metadata/en-US/promotional_text.txt",
+    "type": "text"
+  },
+  {
+    "path": "ios/fastlane/metadata/en-US/release_notes.txt",
+    "type": "text"
+  },
+  {
+    "path": "ios/fastlane/metadata/en-US/subtitle.txt",
+    "type": "text"
+  },
+  {
+    "path": "ios/fastlane/metadata/en-US/support_url.txt",
+    "type": "text"
+  },
+  {
+    "path": "ios/fastlane/metadata/primary_category.txt",
+    "type": "text"
+  },
+  {
+    "path": "ios/fastlane/metadata/primary_first_sub_category.txt",
+    "type": "text"
+  },
+  {
+    "path": "ios/fastlane/metadata/primary_second_sub_category.txt",
+    "type": "text"
+  },
+  {
+    "path": "ios/fastlane/metadata/review_information/review_demo_password.txt",
+    "type": "text"
+  },
+  {
+    "path": "ios/fastlane/metadata/review_information/review_demo_user.txt",
+    "type": "text"
+  },
+  {
+    "path": "ios/fastlane/metadata/review_information/review_email.txt",
+    "type": "text"
+  },
+  {
+    "path": "ios/fastlane/metadata/review_information/review_first_name.txt",
+    "type": "text"
+  },
+  {
+    "path": "ios/fastlane/metadata/review_information/review_last_name.txt",
+    "type": "text"
+  },
+  {
+    "path": "ios/fastlane/metadata/review_information/review_notes.txt",
+    "type": "text"
+  },
+  {
+    "path": "ios/fastlane/metadata/review_information/review_phone_number.txt",
+    "type": "text"
+  },
+  {
+    "path": "ios/fastlane/metadata/secondary_category.txt",
+    "type": "text"
+  },
+  {
+    "path": "ios/fastlane/metadata/secondary_first_sub_category.txt",
+    "type": "text"
+  },
+  {
+    "path": "ios/fastlane/metadata/secondary_second_sub_category.txt",
+    "type": "text"
+  },
+  {
+    "path": "ios/fastlane/screenshots/en-US/APP_IPHONE_55_LANDSCAPE.png",
+    "type": "text"
+  },
+  {
+    "path": "ios/fastlane/screenshots/en-US/APP_IPHONE_55_PORTRAIT.png",
+    "type": "text"
+  },
+  {
+    "path": "ios/fastlane/screenshots/en-US/APP_IPHONE_65_LANDSCAPE.png",
+    "type": "text"
+  },
+  {
+    "path": "ios/fastlane/screenshots/en-US/APP_IPHONE_65_PORTRAIT.png",
+    "type": "text"
+  },
+  {
+    "path": "metro.config.js",
+    "type": "babel"
+  },
+  {
+    "path": "modules/README.md",
+    "type": "text"
+  },
+  {
+    "path": "modules/index.js",
+    "type": "babel"
+  },
+  {
+    "path": "modules/modules.js",
+    "type": "babel"
+  },
+  {
+    "path": "modules/package.json",
+    "type": "json"
+  },
+  {
+    "path": "options/index.js",
+    "type": "babel"
+  },
+  {
+    "path": "options/options.js",
+    "type": "babel"
+  },
+  {
+    "path": "package.json",
+    "type": "json"
+  },
+  {
+    "path": "public/django_index.html",
+    "type": "text"
+  },
+  {
+    "path": "public/index.html",
+    "type": "text"
+  },
+  {
+    "path": "screens/index.js",
+    "type": "babel"
+  },
+  {
+    "path": "screens/package.json",
+    "type": "json"
+  },
+  {
+    "path": "screens/welcome/index.js",
+    "type": "babel"
+  },
+  {
+    "path": "screens/welcome/logo.png",
+    "type": "text"
+  },
+  {
+    "path": "screens/welcome/logo@2x.png",
+    "type": "text"
+  },
+  {
+    "path": "screens/welcome/logo@3x.png",
+    "type": "text"
+  },
+  {
+    "path": "screens/welcome/package.json",
+    "type": "json"
+  },
+  {
+    "path": "screens/welcome/styles.js",
+    "type": "babel"
+  },
+  {
+    "path": "screens/welcome/styles.web.js",
+    "type": "babel"
+  },
+  {
+    "path": "store/README.md",
+    "type": "text"
+  },
+  {
+    "path": "store/config.js",
+    "type": "babel"
+  },
+  {
+    "path": "store/custom/.keep",
+    "type": "text"
+  },
+  {
+    "path": "store/index.js",
+    "type": "babel"
+  },
+  {
+    "path": "store/package.json",
+    "type": "json"
+  },
+  {
+    "path": "tsconfig.json",
+    "type": "json"
+  },
+  {
+    "path": "webpack.config.js",
+    "type": "babel"
+  },
+  {
+    "path": "yarn.lock",
+    "type": "text"
+  }
+]

--- a/scaffold/CHANGELOG.md
+++ b/scaffold/CHANGELOG.md
@@ -2,11 +2,17 @@
 
 Based on [Common Changelog](https://common-changelog.org/).
 
+## 2.1.1 - 2023-06-19
+
+### Fixed
+
+- Fixed web build issue with node_modules compilation.
+
 ## 2.1.0 - 2023-06-19
 
 ### Added
 
-- Support for csrf token to the Django Web build version
+- Support for csrf token to the Django Web build version.
 
 ## 2.0.0 - 2023-05-31
 

--- a/scaffold/package.json
+++ b/scaffold/package.json
@@ -1,6 +1,6 @@
 {
   "name": "template",
   "description": "React Native Template",
-  "version": "2.1.0",
+  "version": "2.1.1",
   "author": "Crowdbotics"
 }

--- a/scaffold/template/custom/.crowdbotics.json
+++ b/scaffold/template/custom/.crowdbotics.json
@@ -1,7 +1,7 @@
 {
   "scaffold": {
     "type": "react-native",
-    "version": "2.1.0",
+    "version": "2.1.1",
     "cookiecutter_context": {
       "project_name": "{{cookiecutter.project_name}}",
       "project_slug": "{{cookiecutter.project_slug}}",

--- a/scaffold/template/custom/webpack.config.js
+++ b/scaffold/template/custom/webpack.config.js
@@ -69,9 +69,8 @@ const babelLoaderConfiguration = {
     path.resolve(appDirectory, "screens"),
     path.resolve(appDirectory, "options"),
     path.resolve(appDirectory, "store"),
-    path.resolve(appDirectory, "node_modules")
+    path.resolve(appDirectory, "node_modules/react-native-reanimated")
   ],
-  exclude: [path.resolve(appDirectory, "node_modules/@babel")],
   use: {
     loader: "babel-loader",
     options: babelOptions


### PR DESCRIPTION
## Ticket

PLAT-11673

## Type of PR

- [x] Bugfix

Did you make changes to the scaffold?

- [x] Yes, and I have read the [scaffold checklist](/docs/scaffold-checklist.md) document and followed the instructions.

Did you make changes to modules or created a new module?

- [ ] Yes, and have read the [modules checklist](/docs/modules-checklist.md) document and followed the instructions.
- [x] No.

## Changes introduced

Removed `node_modules` from the list of paths that are to be transpiled via babel. Included `react-native-reanimated` which is the exception, we want to transpile that library.

## Test and review

Web builds should work locally.
