### PR TITLE
scripts - prevent manifest updates by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 Based on [Common Changelog](https://common-changelog.org/).
 
+## 1.1.1 - 2023-06-19
+
+### Fixed
+
+- Prevent changing existing manifests with `yarn run manifest`.
+
 ## 1.1.0 - 2023-05-31
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "crowdbotics-modules",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "description": "# React Native Scaffold",
   "main": "index.js",
   "bin": {

--- a/scripts/manifest.js
+++ b/scripts/manifest.js
@@ -14,6 +14,13 @@ import { spawnSync } from "node:child_process";
 import config from "../config.js";
 
 const latestUpgrade = config.upgrade.versions.at(-1);
+const forceUpdate = process.argv[2] === "--force";
+const alreadyGenerated = fs.existsSync(path.join(process.cwd(), latestUpgrade.upgradeManifestImport));
+if (alreadyGenerated && !forceUpdate) {
+  console.error("Can't modify existing manifests. Did you add a new version to upgrade.versions in config.js?");
+  console.error("If you really want to force a manifest update use the command flag --force.");
+  process.exit(1);
+}
 const demoDir = path.join(process.cwd(), config.demo.directory);
 const __dirname = process.cwd();
 


### PR DESCRIPTION
## Type of PR

- [x] Minor changes

Did you make changes to the scaffold?

- [ ] Yes, and I have read the [scaffold checklist](/docs/scaffold-checklist.md) document and followed the instructions.
- [x] No.

Did you make changes to modules or created a new module?

- [ ] Yes, and have read the [modules checklist](/docs/modules-checklist.md) document and followed the instructions.
- [x] No.

## Changes introduced

Prevent updating manifest files by default (those are meant to be immutable). Changes to the scaffold are made under a version bump.

Allow for forcing updates with `--force` flag.

## Test and review

Running `yarn run manifest` in this branch should show the error.
