### PR TITLE
Hotfix - read cookiecutter context from .crowdbotics.json

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 Based on [Common Changelog](https://common-changelog.org/).
 
+## 1.1.2 - 2023-06-23
+
+### Fixed
+
+- Read cookiecutter context from .crowdbotics.json when the user's version is not 1.1.0.
+
 ## 1.1.1 - 2023-06-19
 
 ### Fixed

--- a/index.js
+++ b/index.js
@@ -142,9 +142,15 @@ function setupLocalModulesRepo(version) {
   });
 }
 
-function getProjectCookiecutterContext() {
+function getProjectCookiecutterContext(version) {
   section("Detecting your project name, slug, and ssh key fingerprint");
-  const context = {};
+  let context = {};
+  if (version.previousVersion !== "1.1.0") {
+    context = JSON.parse(
+      fs.readFileSync(path.join(userdir, ".crowdbotics.json"), "utf8")
+    ).scaffold.cookiecutter_context;
+    return context;
+  }
 
   const options = {
     ignoreAttributes: false
@@ -666,7 +672,7 @@ const upgrade = (version) => {
     versionCheck(version);
     stashSave();
     setupLocalModulesRepo(version);
-    const context = getProjectCookiecutterContext();
+    const context = getProjectCookiecutterContext(version);
     setupCookiecutter(context, version);
     section("Check files integrity and upgrade to new versions");
     const manifest = JSON.parse(

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "crowdbotics-modules",
-  "version": "1.1.1",
+  "version": "1.1.2",
   "description": "# React Native Scaffold",
   "main": "index.js",
   "bin": {


### PR DESCRIPTION
## Type of PR

- [x] Bugfix

Did you make changes to the scaffold?

- [ ] Yes, and I have read the [scaffold checklist](/docs/scaffold-checklist.md) document and followed the instructions.
- [x] No.

Did you make changes to modules or created a new module?

- [ ] Yes, and have read the [modules checklist](/docs/modules-checklist.md) document and followed the instructions.
- [x] No.

## Changes introduced

Whenever version is not 1.1.0 we can't read project_name and the other context variables from the same exact XML properties. Reading from the [.crowdbotics.json](https://github.com/crowdbotics/modules/blob/df3d8661c2f41b61c14677dd35affc88b2f23912/scaffold/template/custom/.crowdbotics.json#L5-L12) file is more reliable.

## Test and review

Upgrade tool should read from the file instead of parsing xml properties for apps > 1.1.0.
