### PR TITLE
added support for custom project name in add module command

### DIFF
--- a/index.js
+++ b/index.js
@@ -78,13 +78,14 @@ const commands = {
   },
   add: () => {
     const args = arg({
-      "--source": String
+      "--source": String,
+      "--proj": String
     });
     const modules = args._.slice(1);
     if (!modules.length) {
       invalid("please provide the name of the modules to be installed");
     }
-    addModules(modules, args["--source"], "demo");
+    addModules(modules, args["--source"], args["--proj"]);
   },
   remove: () => {
     const args = arg({

--- a/index.js
+++ b/index.js
@@ -79,13 +79,13 @@ const commands = {
   add: () => {
     const args = arg({
       "--source": String,
-      "--proj": String
+      "--project": String
     });
     const modules = args._.slice(1);
     if (!modules.length) {
       invalid("please provide the name of the modules to be installed");
     }
-    addModules(modules, args["--source"], args["--proj"]);
+    addModules(modules, args["--source"], args["--project"]);
   },
   remove: () => {
     const args = arg({

--- a/index.js
+++ b/index.js
@@ -89,13 +89,14 @@ const commands = {
   },
   remove: () => {
     const args = arg({
-      "--source": String
+      "--source": String,
+      "--project": String
     });
     const modules = args._.slice(1);
     if (!modules.length) {
       invalid("please provide the name of the modules to be removed");
     }
-    removeModules(modules, args["--source"], "demo");
+    removeModules(modules, args["--source"], args["--project"]);
   },
   create: () => {
     const args = arg({
@@ -205,6 +206,12 @@ Remove one or modules from your demo app:
 
 Install modules from other directory:
   npx crowdbotics/modules add --source ../other-repository <module-name>
+
+Install modules to other app that is not "demo":
+  npx crowdbotics/modules add --project ../other-project <module-name>
+
+Remove modules from app that is not "demo":
+  npx crowdbotics/modules remove --project ../other-repository <module-name>
 
 Update a module definition from the demo app:
   npx crowdbotics/modules commit <module-name>

--- a/index.js
+++ b/index.js
@@ -211,7 +211,7 @@ Install modules to other app that is not "demo":
   npx crowdbotics/modules add --project ../other-project <module-name>
 
 Remove modules from app that is not "demo":
-  npx crowdbotics/modules remove --project ../other-repository <module-name>
+  npx crowdbotics/modules remove --project ../other-project <module-name>
 
 Update a module definition from the demo app:
   npx crowdbotics/modules commit <module-name>

--- a/scripts/add.js
+++ b/scripts/add.js
@@ -13,7 +13,7 @@ const copy = (origin, target) => {
   fse.copySync(origin, target, { filter: filterFiles });
 };
 
-export function addModules(modules, source = "modules", dir) {
+export function addModules(modules, source = "modules", dir="demo") {
   const cwd = process.cwd();
   const demoDir = path.join(cwd, dir);
 

--- a/scripts/add.js
+++ b/scripts/add.js
@@ -13,7 +13,7 @@ const copy = (origin, target) => {
   fse.copySync(origin, target, { filter: filterFiles });
 };
 
-export function addModules(modules, source = "modules", dir="demo") {
+export function addModules(modules, source = "modules", dir = "demo") {
   const cwd = process.cwd();
   const demoDir = path.join(cwd, dir);
 

--- a/scripts/remove.js
+++ b/scripts/remove.js
@@ -3,7 +3,7 @@ import path from "path";
 import find from "find";
 import { execSync } from "child_process";
 
-export function removeModules(modules, source = "modules", dir) {
+export function removeModules(modules, source = "modules", dir = "demo") {
   const cwd = process.cwd();
   const demoDir = path.join(process.cwd(), dir);
 


### PR DESCRIPTION
## Ticket

Added support for custom project name in `add module` command

Now we support following:
```
npx crowdbotics/modules add MODULE_NAME --project custom-module-dev-43901
```

PLAT-XXXX
_Related tickets:_
_Related PRs:_

## Type of PR

- [ ] Bugfix
- [ ] New feature
- [ ] Minor changes

Did you make changes to modules or created a new module?

- [ ] Yes, and have read the [modules updates checklist](https://github.com/crowdbotics/modules/#modules-updates-checklist) documentation and followed the instructions.
- [ ] No.

## Changes introduced

_Describe the changes being introduced in this PR_
_Include screenshots if necessary_
_Please link any documentation reference that relate to the changes_

## Test and review

_Describe how a reviewer should test your PR_
