### PR TITLE
fix django/react-native meta.json and files paths

### DIFF
--- a/scripts/create.js
+++ b/scripts/create.js
@@ -5,7 +5,7 @@ import { invalid, section } from "../utils.js";
 function generateMeta(name, type) {
   const rootMap = {
     all: "/",
-    "react-native": "/modules",
+    "react-native": `/modules/${name}`,
     django: "/backend/modules"
   };
 
@@ -124,7 +124,7 @@ export function createModule(name, type, target = "modules") {
   section(`generating ${name} module (${type})`);
   switch (type) {
     case "all":
-      generateDjangoFiles(dir, name, `/backend/modules/${name}`);
+      generateDjangoFiles(dir, name, "/backend/modules");
       generateRNFiles(dir, name, `/modules/${name}`);
       break;
     case "react-native":


### PR DESCRIPTION
## Type of PR

- [x] Bugfix
- [ ] New feature
- [ ] Minor changes

Did you make changes to modules or created a new module?

- [ ] Yes, and have read the [modules updates checklist](https://github.com/crowdbotics/modules/#modules-updates-checklist) documentation and followed the instructions.
- [x] No.

## Changes introduced

Added path after `/modules` for `react-native` modules on the `meta.json` file.

## Test and review

```
npx . demo
npx . create --name test --type react-native
npx . add react-native-test
ls demo/modules # should show a directory called "test"
```