### PR TITLE
scripts: commit - add source argument

### DIFF
--- a/index.js
+++ b/index.js
@@ -113,12 +113,14 @@ const commands = {
     createModule(args["--name"], args["--type"], args["--target"]);
   },
   commit: () => {
-    const args = arg({});
+    const args = arg({
+      "--source": String
+    });
     const modules = args._.slice(1);
     if (!modules.length) {
       invalid("please provide the name of the modules to be commited");
     }
-    commitModules(modules, "demo");
+    commitModules(modules, args["--source"]);
   },
   init: () => {
     const args = arg({

--- a/scripts/commit-module.js
+++ b/scripts/commit-module.js
@@ -12,7 +12,7 @@ const copy = (origin, target) => {
   fse.copySync(origin, target, { filter: filterFiles });
 };
 
-export function commitModules(modules, dir) {
+export function commitModules(modules, dir = "demo") {
   const cwd = process.cwd();
   const demoDir = path.join(process.cwd(), dir);
 


### PR DESCRIPTION
## Changes introduced

Introduced new `--source` argument so that one can run the commit command on any project, not just demo projects.

## Test and review

```
npx crowdbotics/modules#scripts/add-source-to-commit commit --source demo
```
