### PR TITLE
PLAT-13347: Guard git-find-root to be executed on demand and validated

### DIFF
--- a/index.js
+++ b/index.js
@@ -46,7 +46,16 @@ if (fs.existsSync(path.join(sourceDir, pkg.name))) {
   sourceDir = path.join(sourceDir, "lib", "node_modules", pkg.name);
 }
 
-const gitRoot = path.dirname(findGitRoot(process.cwd()));
+const gitRoot = () => {
+  try {
+    return path.dirname(findGitRoot(process.cwd()));
+  } catch {
+    invalid(
+      `This command must be executed inside a git repository.
+Visit our official documentation for more information and try again: https://docs.crowdbotics.com/creating-reusable-modules`
+    );
+  }
+};
 
 function dispatcher() {
   const command = process.argv[2];
@@ -65,7 +74,7 @@ function dispatcher() {
 const commands = {
   demo: () => {
     createDemo(
-      path.join(gitRoot, "demo"),
+      path.join(gitRoot(), "demo"),
       path.join(sourceDir, "cookiecutter.yaml")
     );
     valid("demo app successfully generated");
@@ -80,7 +89,7 @@ const commands = {
       invalid("missing required argument: --source");
     }
 
-    const data = parseModules(path.join(args["--source"]), gitRoot);
+    const data = parseModules(path.join(args["--source"]), gitRoot());
     if (args["--write"] && process.exitCode !== 1) {
       fs.mkdirSync(path.dirname(path.join(args["--write"])), {
         recursive: true
@@ -101,7 +110,7 @@ const commands = {
     if (!modules.length) {
       invalid("please provide the name of the modules to be installed");
     }
-    addModules(modules, args["--source"], args["--project"], gitRoot);
+    addModules(modules, args["--source"], args["--project"], gitRoot());
   },
   remove: () => {
     const args = arg({
@@ -112,7 +121,7 @@ const commands = {
     if (!modules.length) {
       invalid("please provide the name of the modules to be removed");
     }
-    removeModules(modules, args["--source"], args["--project"], gitRoot);
+    removeModules(modules, args["--source"], args["--project"], gitRoot());
   },
   create: () => {
     const args = arg({
@@ -131,7 +140,7 @@ const commands = {
         `invalid module name provided: '${args["--name"]}'. Use only alphanumeric characters, dashes and underscores.`
       );
     }
-    createModule(args["--name"], args["--type"], args["--target"], gitRoot);
+    createModule(args["--name"], args["--type"], args["--target"], gitRoot());
   },
   commit: () => {
     const args = arg({
@@ -141,7 +150,7 @@ const commands = {
     if (!modules.length) {
       invalid("please provide the name of the modules to be commited");
     }
-    commitModules(modules, args["--source"], gitRoot);
+    commitModules(modules, args["--source"], gitRoot());
   },
   init: () => {
     const args = arg({


### PR DESCRIPTION
## Ticket

PLAT-13347
_Related tickets:_
_Related PRs:_

## Type of PR

- [x] Bugfix
- [ ] New feature
- [ ] Minor changes

Did you make changes to modules or created a new module?

- [ ] Yes, and have read the [modules updates checklist](https://github.com/crowdbotics/modules/#modules-updates-checklist) documentation and followed the instructions.
- [x] No.

## Changes introduced
- findGitRoot should be called on demand: not all commands require git root and can b e global actions: module listing, login, etc.
- Properly showing helpful validation error 

## Test and review
- using this PR, run the index.js file outside of this repo (in a non-git directory). Expect to see a helpful message that directs user to our documentation on how to use modules.
- try to use a non-git command (e.g. login) and it should work normally

![image](https://github.com/crowdbotics/modules/assets/491204/521e00af-c67a-4607-836b-35f660e73dd2)

- use a command that needs git root inside a git repository should work fine
![image](https://github.com/crowdbotics/modules/assets/491204/36f557b6-0569-4dc6-a3c6-a7dd3e227e79)


