### PR TITLE
Update release-to-qa workflow to work with reusable github-actions

### DIFF
--- a/.github/workflows/release-to-qa.yml
+++ b/.github/workflows/release-to-qa.yml
@@ -19,13 +19,17 @@ jobs:
         run: |
           git clone https://${{ secrets.GIT_TOKEN }}@github.com/${{ github.repository }}.git
 
+      - name: Clone Reusable Actions Repo
+        run: |
+          git clone -b master https://${{ secrets.GIT_TOKEN }}@github.com/crowdbotics/github-actions.git
+
       - name: Checkout branch
         working-directory: ${{ env.working-directory }}
         run: |
           git checkout ${{ env.pr-branch }}
 
       - name: Run Release to QA Workflow
-        uses: crowdbotics/github-actions/release-to-qa@master
+        uses: ./github-actions/release-to-qa
         with:
           working-directory: ${{ env.working-directory }}
           GIT_TOKEN: ${{ secrets.GIT_TOKEN }}


### PR DESCRIPTION
## Ticket

[CBDEVOPS-362](https://crowdbotics.atlassian.net/browse/CBDEVOPS-362)
_Related tickets:_
_Related PRs:_

## Type of PR

- [x] Bugfix
- [ ] New feature
- [ ] Minor changes

Did you make changes to modules or created a new module?

- [ ] Yes, and have read the [modules updates checklist](https://github.com/crowdbotics/modules/#modules-updates-checklist) documentation and followed the instructions.
- [x] No.

## Changes introduced
Clone github-actions repo and use release-to-qa workflow

## Test and review



[CBDEVOPS-362]: https://crowdbotics.atlassian.net/browse/CBDEVOPS-362?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ