### PR TITLE
PLAT-13612: Adjust how CLI is tracked in Amplitude

### DIFF
--- a/index.js
+++ b/index.js
@@ -73,9 +73,6 @@ function dispatcher() {
     invalid(`command doesn't exist: ${command}`);
   }
 
-  // TODO: move this inside the sendEvent
-  Amplitude.init();
-
   return commands[command]();
 }
 
@@ -288,16 +285,17 @@ demo`;
         break;
 
       case "get":
-        Amplitude.sendEvent({
-          name: "View Module Details",
-          properties: { "Module Id": id }
-        });
         id = args._[2];
         if (!id) {
           return invalid(
             "Please provide the id of the module to get, i.e. modules get <123>"
           );
         }
+
+        Amplitude.sendEvent({
+          name: "View Module Details",
+          properties: { "Module Id": id }
+        });
 
         modulesGet(id);
         break;

--- a/index.js
+++ b/index.js
@@ -335,6 +335,9 @@ demo`;
     }
   },
   publish: () => {
+    Amplitude.sendEvent({
+      name: "Publish Modules"
+    });
     publish();
   },
 

--- a/index.js
+++ b/index.js
@@ -36,7 +36,7 @@ import { sendFeedback } from "./scripts/feedback.js";
 import { logout } from "./scripts/logout.js";
 import { modulesArchive, modulesGet, modulesList } from "./scripts/modules.js";
 import { publish } from "./scripts/publish.js";
-import { sendAmplitudeEvent } from "./scripts/amplitude/scripts.js";
+import { Amplitude } from "./scripts/amplitude/wrapper.js";
 
 const pkg = JSON.parse(
   fs.readFileSync(new URL("package.json", import.meta.url), "utf8")
@@ -73,13 +73,8 @@ function dispatcher() {
     invalid(`command doesn't exist: ${command}`);
   }
 
-  // define the properties to track
-  const eventProperties = {
-    full_command: process.argv.slice(2).join(" "), // all of the commands in the user input
-    action: command // Just the first command
-  };
-
-  sendAmplitudeEvent(eventProperties);
+  // TODO: move this inside the sendEvent
+  Amplitude.init();
 
   return commands[command]();
 }
@@ -142,6 +137,7 @@ const commands = {
       "--type": String,
       "--target": String
     });
+
     if (!args["--name"]) {
       invalid("missing required argument: --name");
     }
@@ -153,6 +149,12 @@ const commands = {
         `invalid module name provided: '${args["--name"]}'. Use only alphanumeric characters, dashes and underscores.`
       );
     }
+
+    Amplitude.sendEvent({
+      name: "Create Module",
+      properties: { Name: args["--name"] }
+    });
+
     createModule(args["--name"], args["--type"], args["--target"], gitRoot());
   },
   commit: () => {
@@ -206,6 +208,7 @@ demo`;
     const args = arg({
       "--version": String
     });
+    Amplitude.sendEvent({ name: "Upgrade Scaffold" });
     upgradeScaffold(args["--version"]);
   },
   login: () => {
@@ -275,6 +278,7 @@ demo`;
 
     switch (action) {
       case "list":
+        Amplitude.sendEvent({ name: "List Modules" });
         modulesList({
           search: args["--search"],
           status: args["--status"],
@@ -284,6 +288,10 @@ demo`;
         break;
 
       case "get":
+        Amplitude.sendEvent({
+          name: "View Module Details",
+          properties: { "Module Id": id }
+        });
         id = args._[2];
         if (!id) {
           return invalid(
@@ -301,6 +309,11 @@ demo`;
             "Please provide the id of the module to archive, i.e. modules archive <123>"
           );
         }
+
+        Amplitude.sendEvent({
+          name: args["--unarchive"] ? "Unarchive Module" : "Archive Module",
+          properties: { "Module Id": id }
+        });
 
         modulesArchive(id, !!args["--unarchive"]);
         break;

--- a/scripts/amplitude/constants.js
+++ b/scripts/amplitude/constants.js
@@ -1,2 +1,7 @@
 export const PRODUCTION_AMPLITUDE_KEY = "b48a6aaef8d0ac8df1f2a78196473f06";
 export const DEVELOPMENT_AMPLITUDE_KEY = "8fa9ae919aaf5bbfb85f8275b734b11c";
+
+export const CUSTOMER_TYPE = {
+  SMB: "SMB",
+  ENT: "ENT"
+};

--- a/scripts/amplitude/scripts.js
+++ b/scripts/amplitude/scripts.js
@@ -1,8 +1,7 @@
 import inquirer from "inquirer";
 import { section } from "../../utils.js";
 import { configFile } from "../utils/configFile.js";
-import { AMPLITUDE_API_KEY, HAS_ASKED_OPT_IN_NAME, OPT_IN_NAME } from "./config.js";
-import { init, track } from "@amplitude/analytics-node";
+import { HAS_ASKED_OPT_IN_NAME, OPT_IN_NAME } from "./config.js";
 
 export const askOptIn = async () => {
   const { optInStatus } = await inquirer.prompt({
@@ -11,7 +10,9 @@ export const askOptIn = async () => {
     type: "input"
   });
 
-  if (optInStatus.trim().toLowerCase() !== "y") {
+  const optedIn = optInStatus.trim().toLowerCase() === "y";
+
+  if (!optedIn) {
     section("Thanks for your response. We will not send diagnostics & usage.");
     configFile.set(OPT_IN_NAME, false);
   } else {
@@ -20,24 +21,5 @@ export const askOptIn = async () => {
   }
   configFile.set(HAS_ASKED_OPT_IN_NAME, true);
   configFile.save();
-};
-
-export const sendAmplitudeEvent = (eventProperties) => {
-  const username = configFile.get("email");
-  const isOptedIn = configFile.get(OPT_IN_NAME) || false;
-  try {
-    // track only if email is available and user is opted In
-    if (username && isOptedIn) {
-      init(AMPLITUDE_API_KEY);
-
-      // track the event
-      track("Crowdbotics CLI", eventProperties, {
-        user_id: username
-      });
-    }
-  } catch (error) {
-    track("Crowdbotics CLI", { ...eventProperties, amplitudeError: error }, {
-      user_id: username
-    });
-  }
+  return optedIn;
 };

--- a/scripts/amplitude/wrapper.js
+++ b/scripts/amplitude/wrapper.js
@@ -1,19 +1,11 @@
 import { configFile } from "../utils/configFile.js";
 import { AMPLITUDE_API_KEY, OPT_IN_NAME } from "./config.js";
 import { init, track, Identify, identify } from "@amplitude/analytics-node";
-import { CUSTOMER_TYPE } from "./constants.js";
 import { currentUser } from "../utils/user.js";
 
-/**
- * Wrapper class for Amplitude analytics
- * @class AmplitudeWrapper
- * @property {Object} user - The user object
- */
 class AmplitudeWrapper {
   get userType() {
-    // acceptable return values: CB Employee, Agency, Customer
     // TODO: Implement once we have the data available in the UserSerializer
-    // for is_agency_member and is_internal_cb_employee
     return undefined;
   }
 
@@ -21,35 +13,11 @@ class AmplitudeWrapper {
     return configFile.get(OPT_IN_NAME);
   }
 
-  async init({ token = AMPLITUDE_API_KEY, options = {} } = {}) {
-    if (!this.optedIn) return;
-    if (!token) return;
-    try {
-      init(token, options);
-    } catch {}
+  get appProps() {
+    return {};
   }
 
-  async identifyUser(user) {
-    await currentUser.setUser(user);
-    if (!currentUser.get("id")) return;
-
-    const identifyEvent = new Identify();
-    identifyEvent.set("Django Id", currentUser.get("id"));
-    identify(identifyEvent, {
-      user_id: currentUser.get("email")
-    });
-  }
-
-  getAppProps(app) {
-    if (!app) return {};
-    return {
-      "App Customer Type":
-        app && app.is_enterprise ? CUSTOMER_TYPE.ENT : CUSTOMER_TYPE.SMB,
-      "App ID": app.id
-    };
-  }
-
-  getUserProps() {
+  get userProps() {
     const org = currentUser.get("organization");
     return {
       "User Type": this.userType,
@@ -58,25 +26,42 @@ class AmplitudeWrapper {
     };
   }
 
-  async sendEvent({ name, properties = {}, user, app }) {
-    console.log("Opted in?", this.optedIn);
-    if (!this.optedIn) return;
-    try {
-      await this.identifyUser(user);
-      if (currentUser.get("email")) {
-        const updatedProps = Object.assign(
-          {},
-          properties,
-          this.getAppProps(app),
-          this.getUserProps()
-        );
+  async init({ token = AMPLITUDE_API_KEY, options = {} } = {}) {
+    if (!this.optedIn || !token) return;
 
-        track(name, updatedProps, {
-          user_id: currentUser.get("email")
-        });
+    try {
+      await init(token, { ...options, includeUtm: true }).promise;
+    } catch {
+      // Ignore errors during initialization
+    }
+  }
+
+  async loadAndIdentify(user) {
+    await currentUser.setUser(user);
+    if (!currentUser.get("id")) return;
+
+    const identifyEvent = new Identify();
+    identifyEvent.set("Django Id", currentUser.get("id"));
+    identify(identifyEvent, { user_id: currentUser.get("email") });
+  }
+
+  async sendEvent({ name, properties = {}, user }) {
+    if (!this.optedIn) return;
+
+    try {
+      await this.init();
+      await this.loadAndIdentify(user);
+
+      const userEmail = currentUser.get("email");
+      if (userEmail) {
+        const updatedProps = {
+          ...properties,
+          ...this.appProps,
+          ...this.userProps
+        };
+
+        await track(name, updatedProps, { user_id: userEmail }).promise;
       }
-      // TODO: Remove after done
-      console.log("finished");
     } catch (error) {
       console.warn("Error handling analytics - skipping");
     }

--- a/scripts/amplitude/wrapper.js
+++ b/scripts/amplitude/wrapper.js
@@ -38,7 +38,7 @@ class AmplitudeWrapper {
 
   async loadAndIdentify(user) {
     await currentUser.setUser(user);
-    if (!currentUser.get("id")) return;
+    if (!currentUser.get("email")) return;
 
     const identifyEvent = new Identify();
     identifyEvent.set("Django Id", currentUser.get("id"));

--- a/scripts/amplitude/wrapper.js
+++ b/scripts/amplitude/wrapper.js
@@ -1,0 +1,86 @@
+import { configFile } from "../utils/configFile.js";
+import { AMPLITUDE_API_KEY, OPT_IN_NAME } from "./config.js";
+import { init, track, Identify, identify } from "@amplitude/analytics-node";
+import { CUSTOMER_TYPE } from "./constants.js";
+import { currentUser } from "../utils/user.js";
+
+/**
+ * Wrapper class for Amplitude analytics
+ * @class AmplitudeWrapper
+ * @property {Object} user - The user object
+ */
+class AmplitudeWrapper {
+  get userType() {
+    // acceptable return values: CB Employee, Agency, Customer
+    // TODO: Implement once we have the data available in the UserSerializer
+    // for is_agency_member and is_internal_cb_employee
+    return undefined;
+  }
+
+  get optedIn() {
+    return configFile.get(OPT_IN_NAME);
+  }
+
+  async init({ token = AMPLITUDE_API_KEY, options = {} } = {}) {
+    if (!this.optedIn) return;
+    if (!token) return;
+    try {
+      init(token, options);
+    } catch {}
+  }
+
+  async identifyUser(user) {
+    await currentUser.setUser(user);
+    if (!currentUser.get("id")) return;
+
+    const identifyEvent = new Identify();
+    identifyEvent.set("Django Id", currentUser.get("id"));
+    identify(identifyEvent, {
+      user_id: currentUser.get("email")
+    });
+  }
+
+  getAppProps(app) {
+    if (!app) return {};
+    return {
+      "App Customer Type":
+        app && app.is_enterprise ? CUSTOMER_TYPE.ENT : CUSTOMER_TYPE.SMB,
+      "App ID": app.id
+    };
+  }
+
+  getUserProps() {
+    const org = currentUser.get("organization");
+    return {
+      "User Type": this.userType,
+      "Org ID": org?.id,
+      Source: "CLI"
+    };
+  }
+
+  async sendEvent({ name, properties = {}, user, app }) {
+    console.log("Opted in?", this.optedIn);
+    if (!this.optedIn) return;
+    try {
+      await this.identifyUser(user);
+      if (currentUser.get("email")) {
+        const updatedProps = Object.assign(
+          {},
+          properties,
+          this.getAppProps(app),
+          this.getUserProps()
+        );
+
+        track(name, updatedProps, {
+          user_id: currentUser.get("email")
+        });
+      }
+      // TODO: Remove after done
+      console.log("finished");
+    } catch (error) {
+      console.warn("Error handling analytics - skipping");
+    }
+  }
+}
+
+export const Amplitude = new AmplitudeWrapper();

--- a/scripts/utils/user.js
+++ b/scripts/utils/user.js
@@ -1,0 +1,41 @@
+import { apiClient } from "./apiClient.js";
+
+/**
+ * A more generic approach to cache the current user information for a session.
+ */
+class User {
+  constructor() {
+    this._user = {};
+  }
+
+  get(property) {
+    return this._user[property];
+  }
+
+  async setUser(user) {
+    if (user) {
+      this._user = user;
+    } else {
+      this._user = await this.load();
+    }
+  }
+
+  async load() {
+    console.log("Loading user");
+    try {
+      const response = await apiClient.get({
+        path: "/v2/user/"
+      });
+      if (!response.ok) return {};
+
+      const userBody = await response.json();
+
+      this.user = userBody;
+    } catch {
+      this.user = {};
+    }
+    return this.user;
+  }
+}
+
+export const currentUser = new User();

--- a/scripts/utils/user.js
+++ b/scripts/utils/user.js
@@ -21,7 +21,6 @@ class User {
   }
 
   async load() {
-    console.log("Loading user");
     try {
       const response = await apiClient.get({
         path: "/v2/user/"


### PR DESCRIPTION
## Ticket

PLAT-13612
_Related PRs:_ https://github.com/crowdbotics/vue-dash-5104/pull/4663

## Type of PR

- [ ] Bugfix
- [ ] New feature
- [x] Minor changes

Did you make changes to modules or create a new module?

- [ ] Yes, and have read the [modules updates checklist](https://github.com/crowdbotics/modules/#modules-updates-checklist) documentation and followed the instructions.
- [x] No.

## Changes introduced
Updated amplitude tracking to respect the send the same properties as the Vue dashboard. The following events are being tracked:
- List Modules
- Publish Modules
- View Module Details
- Create Module
- Archive Module
- Unarchive Module
- Upgrade Scaffold


**Notes**: 
- we don't have any app-specific actions in the CLI, so app-related properties were skipped
- Although I introduced the concept of `currentUser` global object, I did not replace other `get /user/` API calls with this global object yet (I wanted to keep the changes scoped to amplitude-related code only)

## Test and review
Test and see if the events mentioned above are being sent to Amplitude.
