### PR TITLE
hotfix: allow server to ignore tracking

### DIFF
--- a/index.js
+++ b/index.js
@@ -67,9 +67,12 @@ Visit our official documentation for more information and try again: https://doc
 };
 
 async function dispatcher() {
+  const args = arg({
+    "--yes": Boolean
+  });
   // check config if they have been asked opted in or out of amplitude
   const hasAskedOptIn = configFile.get(HAS_ASKED_OPT_IN_NAME) || false;
-  if (!hasAskedOptIn && isUserEnvironment) {
+  if (!hasAskedOptIn && isUserEnvironment && !args["--yes"]) {
     await askOptIn();
   }
 
@@ -85,7 +88,7 @@ async function dispatcher() {
 
   await commands[command]();
 
-  if (!analytics.event.name) {
+  if (!analytics.event.name && !args["--yes"]) {
     analytics.sendEvent({
       name: EVENT.OTHER,
       properties: {


### PR DESCRIPTION
## Ticket

PLAT-XXXX
_Related tickets:_
_Related PRs:_

## Type of PR

- [ ] Bugfix
- [ ] New feature
- [ ] Minor changes

Did you make changes to modules or created a new module?

- [ ] Yes, and have read the [modules updates checklist](https://github.com/crowdbotics/modules/#modules-updates-checklist) documentation and followed the instructions.
- [x] No.

## Changes introduced
The back-end always calls the CLI with a flag `--yes` to signal that it is supposed to use the default values. This was no longer needed, but I am leveraging this capability to skip diagnostics when running the CLI from our servers with automated scripts.

## Test and review
Any command with --yes will not send diagnostics nor ask to opt in
