### PR TITLE
PLAT-13620: Adding new environment dependency validation

### DIFF
--- a/index.js
+++ b/index.js
@@ -42,7 +42,10 @@ import { sendFeedback } from "./scripts/feedback.js";
 import { logout } from "./scripts/logout.js";
 import { modulesArchive, modulesGet, modulesList } from "./scripts/modules.js";
 import { publish } from "./scripts/publish.js";
-import { preExecuteChecks } from "./scripts/utils/environment.js";
+import {
+  validateEnvironmentDependencies,
+  EnvironmentDependency
+} from "./scripts/utils/environment.js";
 import { analytics } from "./scripts/analytics/wrapper.js";
 import { HAS_ASKED_OPT_IN_NAME } from "./scripts/analytics/config.js";
 import { EVENT } from "./scripts/analytics/constants.js";
@@ -109,7 +112,10 @@ async function dispatcher() {
 
 const commands = {
   demo: () => {
-    preExecuteChecks();
+    validateEnvironmentDependencies([
+      EnvironmentDependency.Python,
+      EnvironmentDependency.PipEnv
+    ]);
     createDemo(
       path.join(gitRoot(), "demo"),
       path.join(sourceDir, "cookiecutter.yaml")
@@ -139,7 +145,11 @@ const commands = {
     }
   },
   add: () => {
-    preExecuteChecks();
+    validateEnvironmentDependencies([
+      EnvironmentDependency.Python,
+      EnvironmentDependency.Yarn
+    ]);
+
     const args = arg({
       "--source": String,
       "--project": String
@@ -151,6 +161,8 @@ const commands = {
     addModules(modules, args["--source"], args["--project"], gitRoot());
   },
   remove: () => {
+    validateEnvironmentDependencies([EnvironmentDependency.Yarn]);
+
     const args = arg({
       "--source": String,
       "--project": String
@@ -162,7 +174,11 @@ const commands = {
     removeModules(modules, args["--source"], args["--project"], gitRoot());
   },
   create: () => {
-    preExecuteChecks(true);
+    validateEnvironmentDependencies([
+      EnvironmentDependency.Python,
+      EnvironmentDependency.CookieCutter
+    ]);
+
     const args = arg({
       "--name": String,
       "--type": String,
@@ -199,6 +215,8 @@ const commands = {
     commitModules(modules, args["--source"], gitRoot());
   },
   init: () => {
+    validateEnvironmentDependencies([EnvironmentDependency.Git]);
+
     const args = arg({
       "--name": String
     });

--- a/scripts/info.js
+++ b/scripts/info.js
@@ -3,7 +3,7 @@ import { apiClient } from "./utils/apiClient.js";
 import { validateEnvironmentDependencies } from "./utils/environment.js";
 
 export const info = async () => {
-  validateEnvironmentDependencies();
+  validateEnvironmentDependencies(undefined, true);
 
   const response = await apiClient.get({
     path: "/v2/user/"

--- a/scripts/info.js
+++ b/scripts/info.js
@@ -1,9 +1,9 @@
 import { invalid, section } from "../utils.js";
 import { apiClient } from "./utils/apiClient.js";
-import { checkFE } from "./utils/environment.js";
+import { validateEnvironmentDependencies } from "./utils/environment.js";
 
 export const info = async () => {
-  checkFE();
+  validateEnvironmentDependencies();
 
   const response = await apiClient.get({
     path: "/v2/user/"

--- a/scripts/info.js
+++ b/scripts/info.js
@@ -1,7 +1,10 @@
 import { invalid, section } from "../utils.js";
 import { apiClient } from "./utils/apiClient.js";
+import { checkFE } from "./utils/environment.js";
 
 export const info = async () => {
+  checkFE();
+
   const response = await apiClient.get({
     path: "/v2/user/"
   });

--- a/scripts/utils/environment.js
+++ b/scripts/utils/environment.js
@@ -3,7 +3,6 @@ import { invalid, section, valid } from "../../utils.js";
 
 const PYTHON_VERSION_REGEX = /Python (3\.[0-9]*)/;
 
-
 const userdir = process.cwd();
 
 export const execOptions = { encoding: "utf8", stdio: "inherit" };
@@ -32,14 +31,18 @@ export function preExecuteChecks(cookiecutterCheck = false) {
     });
     const userPythonVersion = pythonCheck.stdout || pythonCheck.stderr;
     if (!pythonVersionRegex.test(userPythonVersion)) {
-      invalid(`Found Python version: ${userPythonVersion}. Please install 3.x and try again.`);
+      invalid(
+        `Found Python version: ${userPythonVersion}. Please install 3.x and try again.`
+      );
     }
   } catch (error) {
-    invalid("Error detecting python version, please check install and try again.");
+    invalid(
+      "Error detecting python version, please check install and try again."
+    );
   }
 
   if (cookiecutterCheck) {
-  // Check if Cookiecutter is installed
+    // Check if Cookiecutter is installed
     try {
       execSync("cookiecutter --version", {
         cwd: userdir,
@@ -47,13 +50,15 @@ export function preExecuteChecks(cookiecutterCheck = false) {
         encoding: "utf8"
       });
     } catch (error) {
-      invalid("Cookiecutter is not installed. Please install Cookiecutter before running this command.");
+      invalid(
+        "Cookiecutter is not installed. Please install Cookiecutter before running this command."
+      );
     }
   }
 }
 
 function formatStdout(stdout) {
-  return stdout.replace(/\n/g, "")
+  return stdout.replace(/\n/g, "");
 }
 
 const EnvironmentDependency = {
@@ -61,72 +66,72 @@ const EnvironmentDependency = {
   Git: "git",
   Python: "python",
   PipEnv: "pipenv",
-  CookieCutter: "cookiecutter",
-}
+  CookieCutter: "cookiecutter"
+};
 
 export function getEnvironmentVersions(dependencies) {
   const environmentVersions = {};
 
-  if(dependencies.includes(EnvironmentDependency.Yarn)) {
+  if (dependencies.includes(EnvironmentDependency.Yarn)) {
     const yarn = spawnSync("yarn", ["--version"], {
       cwd: userdir,
       shell: true,
       encoding: "utf8"
     });
 
-    if(!yarn.error && !yarn.stderr) {
+    if (!yarn.error && !yarn.stderr) {
       environmentVersions.yarn = formatStdout(yarn.stdout);
-    } 
+    }
   }
 
-  if(dependencies.includes(EnvironmentDependency.Git)) {
+  if (dependencies.includes(EnvironmentDependency.Git)) {
     const git = spawnSync("git", ["--version"], {
       cwd: userdir,
       shell: true,
       encoding: "utf8"
     });
 
-    if(!git.error && !git.stderr) {
+    if (!git.error && !git.stderr) {
       environmentVersions.git = formatStdout(git.stdout);
-    } 
+    }
   }
 
-  if(dependencies.includes(EnvironmentDependency.Python)) {
+  if (dependencies.includes(EnvironmentDependency.Python)) {
     const python = spawnSync("python", ["--version"], {
       cwd: userdir,
       shell: true,
       encoding: "utf8"
     });
 
-    if(python.stdout && !python.error && !python.stderr) {
+    if (python.stdout && !python.error && !python.stderr) {
       const versionMatch = python.stdout.match(PYTHON_VERSION_REGEX);
-  
-      if(versionMatch && versionMatch[1]) {
-        environmentVersions.python = versionMatch[1]
+
+      if (versionMatch && versionMatch[1]) {
+        environmentVersions.python = versionMatch[1];
       }
     }
   }
 
-  if(dependencies.includes(EnvironmentDependency.PipEnv)) {
+  if (dependencies.includes(EnvironmentDependency.PipEnv)) {
     const pipenv = spawnSync("pipenv", ["--version"], {
       cwd: userdir,
       shell: true,
       encoding: "utf8"
     });
 
-    if(!pipenv.stderr && !pipenv.error) {
+    if (!pipenv.stderr && !pipenv.error) {
       environmentVersions.pipenv = formatStdout(pipenv.stdout);
-    } 
+    }
   }
- 
-  if(EnvironmentDependency.CookieCutter) {
+
+  if (EnvironmentDependency.CookieCutter) {
     const cookiecutter = spawnSync("cookiecutter --version", {
       cwd: userdir,
       shell: true,
       encoding: "utf8"
     });
-  
-    if(!cookiecutter.stderr && !cookiecutter.error) {
+
+    if (!cookiecutter.stderr && !cookiecutter.error) {
       environmentVersions.cookiecutter = cookiecutter.stdout;
     }
   }
@@ -134,13 +139,21 @@ export function getEnvironmentVersions(dependencies) {
   return environmentVersions;
 }
 
-export function validateEnvironmentDependencies(dependencies = [EnvironmentDependency.Yarn, EnvironmentDependency.Git, EnvironmentDependency.Python, EnvironmentDependency.PipEnv, EnvironmentDependency.CookieCutter]) {
+export function validateEnvironmentDependencies(
+  dependencies = [
+    EnvironmentDependency.Yarn,
+    EnvironmentDependency.Git,
+    EnvironmentDependency.Python,
+    EnvironmentDependency.PipEnv,
+    EnvironmentDependency.CookieCutter
+  ]
+) {
   const environmentVersions = getEnvironmentVersions(dependencies);
 
   section("Scaffold upgrade started");
   section("Checking environment compatibility");
 
-  if(dependencies.includes(EnvironmentDependency.Yarn)) {
+  if (dependencies.includes(EnvironmentDependency.Yarn)) {
     if (!environmentVersions.yarn) {
       invalid("yarn is not available in your system");
     } else {
@@ -148,7 +161,7 @@ export function validateEnvironmentDependencies(dependencies = [EnvironmentDepen
     }
   }
 
-  if(dependencies.includes(EnvironmentDependency.Git)) {
+  if (dependencies.includes(EnvironmentDependency.Git)) {
     if (!environmentVersions.git) {
       invalid("git is not available in your system");
     } else {
@@ -156,7 +169,7 @@ export function validateEnvironmentDependencies(dependencies = [EnvironmentDepen
     }
   }
 
-  if(dependencies.includes(EnvironmentDependency.Python)) {
+  if (dependencies.includes(EnvironmentDependency.Python)) {
     if (!environmentVersions.python) {
       invalid("Python 3.x is not available in your system");
     } else {
@@ -164,7 +177,7 @@ export function validateEnvironmentDependencies(dependencies = [EnvironmentDepen
     }
   }
 
-  if(dependencies.includes(EnvironmentDependency.PipEnv)) {
+  if (dependencies.includes(EnvironmentDependency.PipEnv)) {
     if (!environmentVersions.pipenv) {
       invalid("pipenv is not available in your system");
     } else {
@@ -172,7 +185,7 @@ export function validateEnvironmentDependencies(dependencies = [EnvironmentDepen
     }
   }
 
-  if(dependencies.includes(EnvironmentDependency.CookieCutter)) {
+  if (dependencies.includes(EnvironmentDependency.CookieCutter)) {
     if (!environmentVersions.cookiecutter) {
       invalid("cookiecutter is not available in your system");
     } else {

--- a/scripts/utils/environment.js
+++ b/scripts/utils/environment.js
@@ -111,8 +111,9 @@ export function validateEnvironmentDependencies(
 ) {
   section("Checking environment compatibility");
 
-  const cachedEnvironmentVersions =
-    configFile.get(ENVIRONMENT_VERSIONS_CONFIG_NAME) || {};
+  const configValues = configFile.get(ENVIRONMENT_VERSIONS_CONFIG_NAME);
+
+  const cachedEnvironmentVersions = !force && configValues ? configValues : {};
 
   let missingEnvironmentVersions = dependencies;
 
@@ -134,9 +135,14 @@ export function validateEnvironmentDependencies(
   configFile.set(ENVIRONMENT_VERSIONS_CONFIG_NAME, environmentVersions);
   configFile.save();
 
+  const printInvalidMessage = (message) =>
+    invalid(
+      `${message}\n\nVisit the following page for environment requirements https://github.com/crowdbotics/modules?tab=readme-ov-file#requirements-for-contributing`
+    );
+
   if (dependencies.includes(EnvironmentDependency.Yarn)) {
     if (!environmentVersions.yarn) {
-      invalid("yarn is not available in your system");
+      printInvalidMessage("yarn is not available in your system");
     } else {
       valid("yarn version", environmentVersions.yarn);
     }
@@ -144,7 +150,7 @@ export function validateEnvironmentDependencies(
 
   if (dependencies.includes(EnvironmentDependency.Git)) {
     if (!environmentVersions.git) {
-      invalid("git is not available in your system");
+      printInvalidMessage("git is not available in your system");
     } else {
       valid(environmentVersions.git);
     }
@@ -152,7 +158,7 @@ export function validateEnvironmentDependencies(
 
   if (dependencies.includes(EnvironmentDependency.Python)) {
     if (!environmentVersions.python) {
-      invalid("Python 3.x is not available in your system");
+      printInvalidMessage("Python 3.x is not available in your system");
     } else {
       valid(environmentVersions.python);
     }
@@ -160,7 +166,7 @@ export function validateEnvironmentDependencies(
 
   if (dependencies.includes(EnvironmentDependency.PipEnv)) {
     if (!environmentVersions.pipenv) {
-      invalid("pipenv is not available in your system");
+      printInvalidMessage("pipenv is not available in your system");
     } else {
       valid(environmentVersions.pipenv);
     }
@@ -168,7 +174,7 @@ export function validateEnvironmentDependencies(
 
   if (dependencies.includes(EnvironmentDependency.CookieCutter)) {
     if (!environmentVersions.cookiecutter) {
-      invalid("cookiecutter is not available in your system");
+      printInvalidMessage("cookiecutter is not available in your system");
     } else {
       valid(environmentVersions.cookiecutter);
     }

--- a/scripts/utils/environment.js
+++ b/scripts/utils/environment.js
@@ -9,6 +9,14 @@ const userdir = process.cwd();
 
 export const execOptions = { encoding: "utf8", stdio: "inherit" };
 
+export const EnvironmentDependency = {
+  Yarn: "yarn",
+  Git: "git",
+  Python: "python",
+  PipEnv: "pipenv",
+  CookieCutter: "cookiecutter"
+};
+
 /**
  * Setup Python environment to desired version
  * @param {*} options: exec options
@@ -17,59 +25,9 @@ export function configurePython(options = execOptions) {
   execSync("pipenv --python 3.8.17", options);
 }
 
-// TODO - Remove this
-export function preExecuteChecks(cookiecutterCheck = false) {
-  // Check if Python 3.8.x is installed
-
-  try {
-    section("Checking Python version");
-
-    const pythonVersionRegex = /Python 3\.[0-9]*/;
-
-    const pythonCheck = spawnSync("python", ["--version"], {
-      cwd: userdir,
-      shell: true,
-      encoding: "utf8"
-    });
-    const userPythonVersion = pythonCheck.stdout || pythonCheck.stderr;
-    if (!pythonVersionRegex.test(userPythonVersion)) {
-      invalid(
-        `Found Python version: ${userPythonVersion}. Please install 3.x and try again.`
-      );
-    }
-  } catch (error) {
-    invalid(
-      "Error detecting python version, please check install and try again."
-    );
-  }
-
-  if (cookiecutterCheck) {
-    // Check if Cookiecutter is installed
-    try {
-      execSync("cookiecutter --version", {
-        cwd: userdir,
-        shell: true,
-        encoding: "utf8"
-      });
-    } catch (error) {
-      invalid(
-        "Cookiecutter is not installed. Please install Cookiecutter before running this command."
-      );
-    }
-  }
-}
-
 function formatStdout(stdout) {
   return stdout.replace(/\n/g, "");
 }
-
-export const EnvironmentDependency = {
-  Yarn: "yarn",
-  Git: "git",
-  Python: "python",
-  PipEnv: "pipenv",
-  CookieCutter: "cookiecutter"
-};
 
 export function getEnvironmentVersions(dependencies) {
   const environmentVersions = {};
@@ -151,7 +109,6 @@ export function validateEnvironmentDependencies(
   ],
   force = false
 ) {
-  section("Scaffold upgrade started");
   section("Checking environment compatibility");
 
   const cachedEnvironmentVersions =

--- a/scripts/utils/environment.js
+++ b/scripts/utils/environment.js
@@ -1,5 +1,8 @@
 import { execSync, spawnSync } from "node:child_process";
-import { invalid, section } from "../../utils.js";
+import { invalid, section, valid } from "../../utils.js";
+
+const PYTHON_VERSION_REGEX = /Python (3\.[0-9]*)/;
+
 
 const userdir = process.cwd();
 
@@ -13,6 +16,7 @@ export function configurePython(options = execOptions) {
   execSync("pipenv --python 3.8.17", options);
 }
 
+// TODO - Remove this
 export function preExecuteChecks(cookiecutterCheck = false) {
   // Check if Python 3.8.x is installed
 
@@ -44,6 +48,135 @@ export function preExecuteChecks(cookiecutterCheck = false) {
       });
     } catch (error) {
       invalid("Cookiecutter is not installed. Please install Cookiecutter before running this command.");
+    }
+  }
+}
+
+function formatStdout(stdout) {
+  return stdout.replace(/\n/g, "")
+}
+
+const EnvironmentDependency = {
+  Yarn: "yarn",
+  Git: "git",
+  Python: "python",
+  PipEnv: "pipenv",
+  CookieCutter: "cookiecutter",
+}
+
+export function getEnvironmentVersions(dependencies) {
+  const environmentVersions = {};
+
+  if(dependencies.includes(EnvironmentDependency.Yarn)) {
+    const yarn = spawnSync("yarn", ["--version"], {
+      cwd: userdir,
+      shell: true,
+      encoding: "utf8"
+    });
+
+    if(!yarn.error && !yarn.stderr) {
+      environmentVersions.yarn = formatStdout(yarn.stdout);
+    } 
+  }
+
+  if(dependencies.includes(EnvironmentDependency.Git)) {
+    const git = spawnSync("git", ["--version"], {
+      cwd: userdir,
+      shell: true,
+      encoding: "utf8"
+    });
+
+    if(!git.error && !git.stderr) {
+      environmentVersions.git = formatStdout(git.stdout);
+    } 
+  }
+
+  if(dependencies.includes(EnvironmentDependency.Python)) {
+    const python = spawnSync("python", ["--version"], {
+      cwd: userdir,
+      shell: true,
+      encoding: "utf8"
+    });
+
+    if(python.stdout && !python.error && !python.stderr) {
+      const versionMatch = python.stdout.match(PYTHON_VERSION_REGEX);
+  
+      if(versionMatch && versionMatch[1]) {
+        environmentVersions.python = versionMatch[1]
+      }
+    }
+  }
+
+  if(dependencies.includes(EnvironmentDependency.PipEnv)) {
+    const pipenv = spawnSync("pipenv", ["--version"], {
+      cwd: userdir,
+      shell: true,
+      encoding: "utf8"
+    });
+
+    if(!pipenv.stderr && !pipenv.error) {
+      environmentVersions.pipenv = formatStdout(pipenv.stdout);
+    } 
+  }
+ 
+  if(EnvironmentDependency.CookieCutter) {
+    const cookiecutter = spawnSync("cookiecutter --version", {
+      cwd: userdir,
+      shell: true,
+      encoding: "utf8"
+    });
+  
+    if(!cookiecutter.stderr && !cookiecutter.error) {
+      environmentVersions.cookiecutter = cookiecutter.stdout;
+    }
+  }
+
+  return environmentVersions;
+}
+
+export function validateEnvironmentDependencies(dependencies = [EnvironmentDependency.Yarn, EnvironmentDependency.Git, EnvironmentDependency.Python, EnvironmentDependency.PipEnv, EnvironmentDependency.CookieCutter]) {
+  const environmentVersions = getEnvironmentVersions(dependencies);
+
+  section("Scaffold upgrade started");
+  section("Checking environment compatibility");
+
+  if(dependencies.includes(EnvironmentDependency.Yarn)) {
+    if (!environmentVersions.yarn) {
+      invalid("yarn is not available in your system");
+    } else {
+      valid("yarn version", environmentVersions.yarn);
+    }
+  }
+
+  if(dependencies.includes(EnvironmentDependency.Git)) {
+    if (!environmentVersions.git) {
+      invalid("git is not available in your system");
+    } else {
+      valid(environmentVersions.git);
+    }
+  }
+
+  if(dependencies.includes(EnvironmentDependency.Python)) {
+    if (!environmentVersions.python) {
+      invalid("Python 3.x is not available in your system");
+    } else {
+      valid(environmentVersions.python);
+    }
+  }
+
+  if(dependencies.includes(EnvironmentDependency.PipEnv)) {
+    if (!environmentVersions.pipenv) {
+      invalid("pipenv is not available in your system");
+    } else {
+      valid(environmentVersions.pipenv);
+    }
+  }
+
+  if(dependencies.includes(EnvironmentDependency.CookieCutter)) {
+    if (!environmentVersions.cookiecutter) {
+      invalid("cookiecutter is not available in your system");
+    } else {
+      valid(environmentVersions.cookiecutter);
     }
   }
 }

--- a/scripts/utils/environment.js
+++ b/scripts/utils/environment.js
@@ -63,7 +63,7 @@ function formatStdout(stdout) {
   return stdout.replace(/\n/g, "");
 }
 
-const EnvironmentDependency = {
+export const EnvironmentDependency = {
   Yarn: "yarn",
   Git: "git",
   Python: "python",


### PR DESCRIPTION
## Ticket

Looking for feedback here, work in progress.


**Proposed method of usage:**

Command can opt into the environment checks it wants:
```javascript
const command = () => {
  validateEnvironmentDependencies([EnvironmentDependency.Yarn, EnvironmentDependency.Git]);
  
  // can continue with command
}
```

By default, all dependencies expected will be validated:
```javascript
const command = () => {
  validateEnvironmentDependencies();
  
  // can continue with command
}
```

Previous dependency validations will be cached. Command can force re-validation if necessary
```javascript
const command = () => {
  validateEnvironmentDependencies([EnvironmentDependency.Yarn], true);
  
  // can continue with command
}
```

PLAT-13620
_Related tickets:_
_Related PRs:_

## Type of PR

- [ ] Bugfix
- [X] New feature
- [ ] Minor changes

Did you make changes to modules or created a new module?

- [ ] Yes, and have read the [modules updates checklist](https://github.com/crowdbotics/modules/#modules-updates-checklist) documentation and followed the instructions.
- [X] No.

## Changes introduced

- Adding a centralized way to validate environment
- Caches previously validated environment options to reduce overhead

## Test and review

_Describe how a reviewer should test your PR_
