### PR TITLE
hotfix: default host for events should always be production

### DIFF
--- a/scripts/analytics/config.js
+++ b/scripts/analytics/config.js
@@ -1,5 +1,5 @@
 import { configFile } from "../utils/configFile.js";
-import { HOST_CONFIG_NAME } from "../utils/constants.js";
+import { HOST_CONFIG_NAME, DEFAULT_HOST } from "../utils/constants.js";
 import {
   DEVELOPMENT_SEGMENT_KEY,
   PRODUCTION_SEGMENT_KEY
@@ -9,6 +9,6 @@ export const HAS_ASKED_OPT_IN_NAME = "has-asked-opt-in";
 export const OPT_IN_NAME = "opt-in";
 
 export const SEGMENT_API_KEY =
-  configFile.get(HOST_CONFIG_NAME) === "https://app.crowdbotics.com/"
+  configFile.get(HOST_CONFIG_NAME) === DEFAULT_HOST
     ? PRODUCTION_SEGMENT_KEY
     : DEVELOPMENT_SEGMENT_KEY;


### PR DESCRIPTION
## Ticket

PLAT-XXXX
_Related tickets:_
_Related PRs:_

## Type of PR

- [x] Bugfix
- [ ] New feature
- [ ] Minor changes

Did you make changes to modules or created a new module?

- [ ] Yes, and have read the [modules updates checklist](https://github.com/crowdbotics/modules/#modules-updates-checklist) documentation and followed the instructions.
- [ ] No.

## Changes introduced
Amplitude events are never being sent to production because the comparison between the host value (compared to the default host) was off one character (/)


## Test and review
Set host to production URL
Notice SEGMENT_API_KEY being the production key, not staging 
