### PR TITLE
ci(config.yml): update Xcode version and resource class for iOS job

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -29,8 +29,8 @@ jobs:
 
   ios:
     macos:
-      xcode: "14.1.0"
-    resource_class: macos.x86.medium.gen2
+      xcode: "14.2.0"
+    resource_class: macos.m1.medium.gen1
     working_directory: ~/build/demo
 
     # use a --login shell so our "set Ruby version" command gets picked up for later steps


### PR DESCRIPTION
Update the Xcode version from 14.1.0 to 14.2.0 to ensure compatibility with the latest iOS features and improvements. Change the resource class from macos.x86.medium.gen2 to macos.m1.medium.gen1 to leverage the performance benefits of Apple's M1 architecture, which can lead to faster build times and more efficient resource usage.

## Ticket

PLAT-XXXX
_Related tickets:_
_Related PRs:_

## Type of PR

- [ ] Bugfix
- [ ] New feature
- [ ] Minor changes

Did you make changes to modules or created a new module?

- [ ] Yes, and have read the [modules updates checklist](https://github.com/crowdbotics/modules/#modules-updates-checklist) documentation and followed the instructions.
- [ ] No.

## Changes introduced

_Describe the changes being introduced in this PR_
_Include screenshots if necessary_
_Please link any documentation reference that relate to the changes_

## Test and review

_Describe how a reviewer should test your PR_
